### PR TITLE
Skills: General overhaul

### DIFF
--- a/src/app/skills/description-ui/description-ui.component.ts
+++ b/src/app/skills/description-ui/description-ui.component.ts
@@ -15,6 +15,7 @@ export class DescriptionUiComponent implements OnInit {
 
   html(): string {
     return this.template
+      .replace("%(AltCombo)", "<b class=\"tooltip-header\">Alt. Combo:</b>")
       .replace("%(ChargeUp)", "<b class=\"tooltip-header\">Charge Up:</b>")
       .replace("%(DamageCombo)", "<b class=\"tooltip-header\">Damage Combo:</b>")
       .replace("%(Description)", "<b class=\"tooltip-header\">Description:</b>");

--- a/src/app/skills/description-ui/description-ui.component.ts
+++ b/src/app/skills/description-ui/description-ui.component.ts
@@ -6,7 +6,7 @@ import { Component, Input, OnInit } from '@angular/core';
   styleUrls: ['./description-ui.component.css']
 })
 export class DescriptionUiComponent implements OnInit {
-  @Input() template: string;
+  @Input() template?: string;
 
   constructor() { }
 
@@ -14,6 +14,7 @@ export class DescriptionUiComponent implements OnInit {
   }
 
   html(): string {
+    if (!this.template) return "";
     return this.template
       .replace("%(AltCombo)", "<b class=\"tooltip-header\">Alt. Combo:</b>")
       .replace("%(ChargeUp)", "<b class=\"tooltip-header\">Charge Up:</b>")

--- a/src/app/skills/skill/skill.component.html
+++ b/src/app/skills/skill/skill.component.html
@@ -15,6 +15,30 @@
     </a>
   </p>
   <!--<app-behavior-detail [behaviorID]="skill.behaviorID"></app-behavior-detail>-->
+  <section>
+    <h3>Flags</h3>
+
+    <lux-number-flag *ngIf="skill.skillID !== null" [value]="skill.skillID" name="skillID"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.locStatus !== null" [value]="skill.locStatus" name="locStatus"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.behaviorID !== null" [value]="skill.behaviorID" name="behaviorID"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.imaginationcost !== null" [value]="skill.imaginationcost" name="imaginationcost"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.cooldowngroup !== null" [value]="skill.cooldowngroup" name="cooldowngroup"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.cooldown !== null" [value]="skill.cooldown" name="cooldown"></lux-number-flag>
+    <lux-simple-flag *ngIf="skill.inNpcEditor !== null" [value]="skill.inNpcEditor" name="inNpcEditor"></lux-simple-flag>
+    <lux-number-flag *ngIf="skill.skillIcon !== null" [value]="skill.skillIcon" name="skillIcon"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.oomBehaviorEffectID !== null" [value]="skill.oomBehaviorEffectID" name="oomBehaviorEffectID"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.castTypeDesc !== null" [value]="skill.castTypeDesc" name="castTypeDesc"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.imBonusUI !== null" [value]="skill.imBonusUI" name="imBonusUI"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.lifeBonusUI !== null" [value]="skill.lifeBonusUI" name="lifeBonusUI"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.armorBonusUI !== null" [value]="skill.armorBonusUI" name="armorBonusUI"></lux-number-flag>
+    <lux-number-flag *ngIf="skill.damageUI !== null" [value]="skill.damageUI" name="damageUI"></lux-number-flag>
+    <lux-simple-flag *ngIf="skill.hideIcon !== null" [value]="skill.hideIcon" name="hideIcon"></lux-simple-flag>
+    <lux-simple-flag *ngIf="skill.localize !== null" [value]="skill.localize" name="localize"></lux-simple-flag>
+    <lux-number-flag *ngIf="skill.cancelType !== null" [value]="skill.cancelType" name="cancelType"></lux-number-flag>
+
+    <blockquote *ngIf="skill.oomSkillID !== null"><b>oomSkillID:</b> {{skill.oomSkillID}}</blockquote>
+    <blockquote *ngIf="skill.gate_version !== null"><b>gate_version:</b> {{skill.gate_version}}</blockquote>
+  </section>
 </div>
 <section *ngIf="$rev_skill | async; let rev_skill">
   <h3>Used in</h3>
@@ -34,7 +58,7 @@
     <h4>ObjectSkills</h4>
     <p>The following objects can cast this skill:</p>
     <ng-container *ngFor="let object_id of rev_skill.objects">
-      <lux-gui-item [id]="object_id"></lux-gui-item>
+      <lux-slot [luxFetchItem]="object_id"></lux-slot>
     </ng-container>
   </section>
   <section *ngIf="rev_skill.item_sets.length > 0">
@@ -42,10 +66,10 @@
     {{rev_skill.item_sets}}
   </section>
 </section>
-<section *ngIf="_skill | async; let skill">
+<!--<section *ngIf="_skill | async; let skill">
   <h3>Details</h3>
   <app-data-table [table]="skill"></app-data-table>
-</section>
+</section>-->
 <ng-template #loading>
   Loading...
 </ng-template>

--- a/src/app/skills/skill/skill.component.html
+++ b/src/app/skills/skill/skill.component.html
@@ -8,19 +8,14 @@
     <b>UI Description (<code>descriptionUI</code>):</b>
     <app-description-ui [template]="texts['descriptionUI']"></app-description-ui>
   </ng-container>
-  <h3>Behavior</h3>
-  <p>
-    <a routerLink="/skills/behaviors/{{skill.behaviorID}}">
-      <lux-number-flag [value]="skill.behaviorID" name="behaviorID"></lux-number-flag>
-    </a>
-  </p>
-  <!--<app-behavior-detail [behaviorID]="skill.behaviorID"></app-behavior-detail>-->
   <section>
     <h3>Flags</h3>
 
     <lux-number-flag *ngIf="skill.skillID !== null" [value]="skill.skillID" name="skillID"></lux-number-flag>
     <lux-number-flag *ngIf="skill.locStatus !== null" [value]="skill.locStatus" name="locStatus"></lux-number-flag>
-    <lux-number-flag *ngIf="skill.behaviorID !== null" [value]="skill.behaviorID" name="behaviorID"></lux-number-flag>
+    <a routerLink="/skills/behaviors/{{skill.behaviorID}}">
+      <lux-number-flag [value]="skill.behaviorID" name="behaviorID"></lux-number-flag>
+    </a>
     <lux-number-flag *ngIf="skill.imaginationcost !== null" [value]="skill.imaginationcost" name="imaginationcost"></lux-number-flag>
     <lux-number-flag *ngIf="skill.cooldowngroup !== null" [value]="skill.cooldowngroup" name="cooldowngroup"></lux-number-flag>
     <lux-number-flag *ngIf="skill.cooldown !== null" [value]="skill.cooldown" name="cooldown"></lux-number-flag>

--- a/src/app/skills/skill/skill.component.html
+++ b/src/app/skills/skill/skill.component.html
@@ -15,9 +15,37 @@
     </a>
   </p>
   <!--<app-behavior-detail [behaviorID]="skill.behaviorID"></app-behavior-detail>-->
+</div>
+<section *ngIf="$rev_skill | async; let rev_skill">
+  <h3>Used in</h3>
+  <section *ngIf="rev_skill.mission_tasks.length > 0">
+    <h4>UseSkill MissionTasks</h4>
+    <p>The following mission tasks require you to cast this skill:</p>
+    <dl>
+    <ng-container *ngFor="let task_id of rev_skill.mission_tasks">
+      <ng-container *ngIf="rev_skill._embedded.MissionTasks| elem: task_id.toString(); let task">
+        <dt>Mission <a routerLink="/missions/{{task.id}}">#{{task.id}}</a>:</dt>
+        <dd><app-task-detail [task]="task"></app-task-detail></dd>
+      </ng-container>
+    </ng-container>
+    </dl>
+  </section>
+  <section *ngIf="rev_skill.objects.length > 0">
+    <h4>ObjectSkills</h4>
+    <p>The following objects can cast this skill:</p>
+    <ng-container *ngFor="let object_id of rev_skill.objects">
+      <lux-gui-item [id]="object_id"></lux-gui-item>
+    </ng-container>
+  </section>
+  <section *ngIf="rev_skill.item_sets.length > 0">
+    <h4>ItemSet SkillSets</h4>
+    {{rev_skill.item_sets}}
+  </section>
+</section>
+<section *ngIf="_skill | async; let skill">
   <h3>Details</h3>
   <app-data-table [table]="skill"></app-data-table>
-</div>
+</section>
 <ng-template #loading>
   Loading...
 </ng-template>

--- a/src/app/skills/skill/skill.component.ts
+++ b/src/app/skills/skill/skill.component.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { map, tap, switchMap } from 'rxjs/operators';
 
 import { LuJsonService } from '../../services';
-import { DB_MissionTasks, DB_SkillBehavior } from '../../cdclient';
+import { DB_MissionTasks, DB_SkillBehavior } from '../../../defs/cdclient';
 import { LuCoreDataService } from '../../util/services/lu-core-data.service';
 
 

--- a/src/app/skills/skill/skill.component.ts
+++ b/src/app/skills/skill/skill.component.ts
@@ -4,7 +4,21 @@ import { Observable } from 'rxjs';
 import { map, tap, switchMap } from 'rxjs/operators';
 
 import { LuJsonService } from '../../services';
-import { DB_SkillBehavior } from '../../../defs/cdclient';
+import { DB_MissionTasks, DB_SkillBehavior } from '../../cdclient';
+import { LuCoreDataService } from '../../util/services/lu-core-data.service';
+
+
+interface Rev_Skill_Embedded {
+  MissionTasks: {[key: number]: DB_MissionTasks}
+}
+
+interface Rev_Skill {
+  mission_tasks: number[],
+  objects: number[],
+  // NOTE: this is actually item_sets_skill_set
+  item_sets: number[],
+  _embedded: Rev_Skill_Embedded,
+}
 
 @Component({
   selector: 'app-skill',
@@ -15,20 +29,22 @@ export class SkillComponent implements OnInit {
 
   id: number;
   _skill: Observable<DB_SkillBehavior>;
+  $rev_skill: Observable<Rev_Skill>;
 
   constructor(
   	private route: ActivatedRoute,
     private luJsonService: LuJsonService,
+    private luCoreDataService: LuCoreDataService,
     private cd: ChangeDetectorRef) { }
 
   ngOnInit() {
-    this._skill = this.route.paramMap.pipe(
+    let $id = this.route.paramMap.pipe(
       map(map => +map.get('id')),
       tap(id => {
         this.id = id;
         this.cd.detectChanges();
-      }),
-      switchMap(id => this.luJsonService.getSkill(id))
-    );
+      }));
+    this._skill = $id.pipe(switchMap(id => this.luJsonService.getSkill(id)));
+    this.$rev_skill = $id.pipe(switchMap(id => this.luCoreDataService.getRevEntry<Rev_Skill>('skill_ids', id)));
   }
 }

--- a/src/app/skills/skills.module.ts
+++ b/src/app/skills/skills.module.ts
@@ -10,6 +10,7 @@ import { SkillComponent } from './skill/skill.component';
 import { SkillsRoutingModule } from './skills-routing.module';
 import { SkillsComponent } from './skills.component';
 import { DescriptionUiComponent } from './description-ui/description-ui.component';
+import { TasksModule } from '../missions/tasks/tasks.module';
 import { GuiModule } from '../gui/gui.module';
 
 @NgModule({
@@ -22,9 +23,10 @@ import { GuiModule } from '../gui/gui.module';
   ],
   imports: [
     CommonModule,
+    GuiModule,
     UtilModule,
     SkillsRoutingModule,
-    GuiModule
+    TasksModule,
   ]
 })
 export class SkillsModule { }

--- a/src/app/util/pipes/service.pipe.ts
+++ b/src/app/util/pipes/service.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { LuDocsService, LuResService, LuLocaleService, LuJsonService } from '../../services';
 
 @Pipe({ name: 'docs' })
@@ -57,7 +57,7 @@ export class DataPipe implements PipeTransform {
       faction: x => this.luJson.getFaction(x),
       activityRewards: x => this.luJson.getActivityRewards(x),
     }[arg];
-    if (arg) return call(value);
+    return arg ? call(value) : of(null);
   }
 
 }


### PR DESCRIPTION
This PR implementes the first inverse lookup on foreign key relations. This way, we get much richer information about a skill, object or mission. The actual implementation uses a new prototype API from <https://github.com/xiphoseer/lu-res-api-server>.

Example for skills (WIP, notice that the task description is missing):

![grafik](https://user-images.githubusercontent.com/14206221/132836817-9864bcb0-3125-4f6c-aa6c-ff72e5c09e7b.png)
Datasource: <https://explorer.lu/api/v0/rev/skill_ids/1160>

// cc: @lcdr

## TODO

- [ ] fix the behavior tree view in `/skills/{id}`