### PR TITLE
Fix mission list separator

### DIFF
--- a/src/app/missions/by-subtype/by-subtype.component.css
+++ b/src/app/missions/by-subtype/by-subtype.component.css
@@ -1,6 +1,5 @@
 .mission-separator {
-    break-before: always;
-    break-after: always;
+    flex-basis: 100%;
     height: 2rem;
     order: 0;
 }


### PR DESCRIPTION
The mission/achievement list view includes a separator which is supposed to automatically insert a row between missions and achievements, this worked at one point but now doesn't, not sure what changed. Fixing with a better solution.