### PR TITLE
Fix API config not setting credentials

### DIFF
--- a/src/app/util/services/lu-core-data.service.ts
+++ b/src/app/util/services/lu-core-data.service.ts
@@ -31,7 +31,7 @@ export class ApiConfig {
     pass?: string,
   }) {
     this.base = options.base;
-    if (this.user != null && this.user.length > 0) {
+    if (options.user != null && options.user.length > 0) {
       this.user = options.user;
       this.pass = options.pass;
     }


### PR DESCRIPTION
Code checked newly initialized credentials instead of provided credentials.