### PR TITLE
Implement SQL query API

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { BrowserModule, Title }    from '@angular/platform-browser';
 import { NgModule }         from '@angular/core';
+import { AsyncPipe } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { FormsModule }      from '@angular/forms';
 
@@ -34,6 +35,7 @@ import { SearchService } from './util/services/search.service';
     LuLocaleService,
     LuDocsService,
     SearchService,
+    AsyncPipe,
     Title,
   ],
   bootstrap: [AppComponent]

--- a/src/app/util/pipes/service.pipe.ts
+++ b/src/app/util/pipes/service.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
 import { Observable, of, zip } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { DB_Icons } from '../../../defs/cdclient';
@@ -92,5 +93,15 @@ export class DataPipe implements PipeTransform {
       lootTable: x => this.coreData.getRevEntry("loot_table_index", x),
     }[arg];
     return arg ? call(value) : of(null);
+  }
+}
+
+@Pipe({ name: 'query', pure: false })
+export class QueryPipe implements PipeTransform {
+
+  constructor(private luCoreData: LuCoreDataService, private asyncPipe: AsyncPipe) { }
+
+  transform(value: string): any[] {
+    return this.asyncPipe.transform(this.luCoreData.querySql(value));
   }
 }

--- a/src/app/util/services/lu-core-data.service.ts
+++ b/src/app/util/services/lu-core-data.service.ts
@@ -83,7 +83,7 @@ export class LuCoreDataService {
     if (!this.cache.has(url)) {
       let httpRequest = this.$apiUrl.pipe(switchMap(cfg => this.http.get(cfg.base + url, {
         headers: cfg.headers(),
-        responseType: responseType as "json",
+        responseType: responseType,
         withCredentials: cfg.withCredentials,
       })))
         .pipe(

--- a/src/app/util/util.module.ts
+++ b/src/app/util/util.module.ts
@@ -9,7 +9,7 @@ import { GithubSpaComponent } from './github-spa/github-spa.component';
 import { ArraySortPipe, ArraySortNumPipe, DefaultPipe, DictPipe, ElementPipe, GroupPipe, KeysPipe, LimitPipe, NonNullPipe, RangePipe, RemovePipe, MaxUpToPipe, ArrKeysPipe, KeySetPipe, ParamSetPipe, AsArrayPipe } from './pipes/data.pipe';
 import { BitsPipe, BitSetPipe, BitAndPipe, BitOrPipe, BitShiftRightPipe, BitShiftLeftPipe, NotPipe, SomePipe, DivCeilPipe } from './pipes/logical.pipe';
 import { DatePipe, HtmlPipe, FixedNumPipe } from './pipes/output.pipe';
-import { DocsPipe, ResourcePipe, LocalePipe, DataPipe, TranslatePipe, IconPipe } from './pipes/service.pipe';
+import { DocsPipe, QueryPipe, ResourcePipe, LocalePipe, DataPipe, TranslatePipe, IconPipe } from './pipes/service.pipe';
 import { ReplacePipe, PercentPipe, ToPipe, ToNumPipe, ToRGBAPipe, TocPipe } from './pipes/strings.pipe';
 import { PcPipe } from './pipes/pc.pipe';
 import { CondAstPipe } from './pipes/conditions.pipe';
@@ -28,7 +28,7 @@ export { LuResService, LuDocsService, LuLocaleService };
     BitsPipe, BitSetPipe, BitAndPipe, BitOrPipe, BitShiftRightPipe, BitShiftLeftPipe, NotPipe, SomePipe, DivCeilPipe,
     KeySetPipe, ParamSetPipe, AsArrayPipe,
     DatePipe, HtmlPipe, FixedNumPipe,
-    DocsPipe, ResourcePipe, LocalePipe, DataPipe, TranslatePipe,
+    DocsPipe, QueryPipe, ResourcePipe, LocalePipe, DataPipe, TranslatePipe,
     ReplacePipe, PercentPipe, ToPipe, ToNumPipe, ToRGBAPipe,
     PcPipe, CondAstPipe, TocPipe, IconPipe,
     LuxVarDirective,
@@ -43,7 +43,7 @@ export { LuResService, LuDocsService, LuLocaleService };
     LimitPipe, MaxUpToPipe, KeySetPipe, ParamSetPipe, AsArrayPipe,
     BitsPipe, BitSetPipe, BitAndPipe, BitOrPipe, BitShiftRightPipe, BitShiftLeftPipe, NotPipe, SomePipe, DivCeilPipe,
     DatePipe, HtmlPipe, FixedNumPipe,
-    DocsPipe, ResourcePipe, LocalePipe, DataPipe, TranslatePipe,
+    DocsPipe, QueryPipe, ResourcePipe, LocalePipe, DataPipe, TranslatePipe,
     ReplacePipe, PercentPipe, ToPipe, ToNumPipe, ToRGBAPipe,
     PcPipe, CondAstPipe, TocPipe, IconPipe,
     LuxVarDirective,


### PR DESCRIPTION
The frontend counterpart to the backend API endpoint, this adds a new method `querySql` to the core data service, which accepts an arbitrary SQL string, sends it to the backend, parses the response CSV into an array of objects with the columns as properties, and returns this array.

The parsing also properly supports the escaping of quotes in the CSV, in accordance with the official CSV RFC.

Since this doesn't use angular's standard json parsing functionality, I had to modify the `get` method a bit to accept text and to be able to add in the parsing before the result is cached, so that the cache uses the parsed array instead of the CSV text.

There is no type parsing as of yet, all results are returned as string, except for `null`, which is properly detected and returned as JS `null`. Maybe some parsing is possible based on the cdclient defs, but this would quickly get complicated as one of the main uses of this API is to do joins and computed columns which do not easily map to the raw cdclient defs. However, from initial testing (soon to be PRed itself), the new API allows almost all computation to be offloaded to the DB layer, leaving the components mostly just to render the resulting strings in the right places, so basically no type conversion is needed anyway.

This PR also adds a new pipe, `query`, to be used in HTML templates, which accepts an SQL string and returns the aforementioned parsed array. Since this would normally return an Observable that would almost always immediately be handed over to the `async` pipe, the `async` pipe is integrated into the `query` pipe so that a single pipe suffices.