### PR TITLE
Factor out ItemDirective into ItemTooltipDirective

### DIFF
--- a/src/app/gui/gui.module.ts
+++ b/src/app/gui/gui.module.ts
@@ -4,6 +4,7 @@ import { IconDirective } from './icon/icon.directive';
 import { ItemDirective } from './item/item.directive';
 import { ItemSetComponent } from './item-set/item-set.component';
 import { ItemTooltipComponent } from './item-tooltip/item-tooltip.component';
+import { ItemTooltipDirective } from './item-tooltip/item-tooltip.directive';
 import { UtilModule } from '../util/util.module';
 import { RouterModule } from '@angular/router';
 import { CoinsComponent } from './coins/coins.component';
@@ -43,6 +44,7 @@ const COMPONENTS = [
   ItemDirective,
   ItemSetComponent,
   ItemTooltipComponent,
+  ItemTooltipDirective,
   TooltipComponent,
   TooltipDirective,
   FactionListComponent,

--- a/src/app/gui/item-tooltip/item-tooltip.directive.spec.ts
+++ b/src/app/gui/item-tooltip/item-tooltip.directive.spec.ts
@@ -1,0 +1,8 @@
+import { ItemTooltipDirective } from "./item-tooltip.directive";
+
+describe("ItemTooltipDirective", () => {
+  it("should create an instance", () => {
+    //const directive = new ItemTooltipDirective();
+    //expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/gui/item-tooltip/item-tooltip.directive.ts
+++ b/src/app/gui/item-tooltip/item-tooltip.directive.ts
@@ -1,0 +1,47 @@
+import { ApplicationRef, ComponentRef, ElementRef, Directive, Injector, Input, Renderer2, createComponent, EnvironmentInjector } from "@angular/core";
+import { ItemTooltipComponent } from "./item-tooltip.component";
+import { TooltipDirective } from "../tooltip.directive";
+import { LuCoreDataService } from "../../services";
+import { DB_Objects } from "../../../defs/cdclient";
+
+@Directive({
+  selector: "lux-slot[luxItemTooltip]"
+})
+export class ItemTooltipDirective extends TooltipDirective {
+  protected itemTooltipRef: ComponentRef<ItemTooltipComponent>;
+
+  @Input("luxItemTooltip") set id(id: number) {
+    this.itemTooltipRef.instance.id = id;
+    this.itemTooltipRef.instance.title = "[Unknown]";
+  }
+
+  constructor(
+    element: ElementRef<HTMLElement>,
+    applicationRef: ApplicationRef,
+    renderer: Renderer2,
+    injector: Injector,
+    environmentInjector: EnvironmentInjector,
+    protected coreData: LuCoreDataService
+  ) {
+    super(element, applicationRef, renderer, injector);
+
+    this.itemTooltipRef = createComponent(ItemTooltipComponent, { environmentInjector });
+    this.content = this.itemTooltipRef;
+  }
+
+  mouseenter() {
+    if (this.itemTooltipRef.instance.title == "[Unknown]") {
+      this.coreData.getSingleTableEntry('Objects', this.itemTooltipRef.instance.id).subscribe(this.onObjectsRow.bind(this));
+    }
+    super.mouseenter();
+  }
+
+  onObjectsRow(object: DB_Objects) {
+    if (object.displayName) {
+      this.itemTooltipRef.instance.title = object.displayName;
+    } else if (object.name) {
+      this.itemTooltipRef.instance.title = object.name;
+    }
+    this.itemTooltipRef.changeDetectorRef.detectChanges();
+  }
+}

--- a/src/app/gui/item/item.directive.ts
+++ b/src/app/gui/item/item.directive.ts
@@ -1,22 +1,17 @@
-import { ApplicationRef, ComponentRef, ElementRef, Directive, Injector, Input, Renderer2, createComponent, EnvironmentInjector } from "@angular/core";
-import { ItemTooltipComponent } from "../item-tooltip/item-tooltip.component";
+import { ApplicationRef, ElementRef, Directive, Injector, Input, Renderer2, EnvironmentInjector } from "@angular/core";
+import { ItemTooltipDirective } from "../item-tooltip/item-tooltip.directive";
 import { SlotComponent } from "../slot/slot.component";
-import { TooltipDirective } from "../tooltip.directive";
 import { LuCoreDataService } from "../../services";
-import { DB_ComponentsRegistry, DB_Objects } from "../../../defs/cdclient";
+import { DB_ComponentsRegistry } from "../../../defs/cdclient";
 import { RENDER_COMPONENT_ID } from "../../../defs/components";
 
 @Directive({
   selector: "lux-slot[luxFetchItem]"
 })
-export class ItemDirective extends TooltipDirective {
-  private itemTooltipRef: ComponentRef<ItemTooltipComponent>;
-
+export class ItemDirective extends ItemTooltipDirective {
   @Input("luxFetchItem") set id(id: number) {
+    super.id = id;
     this.slotComponent.link = `/objects/${id}`;
-    this.itemTooltipRef.instance.id = id;
-    this.itemTooltipRef.instance.title = `[Unknown]`;
-    this.coreData.getSingleTableEntry('Objects', id).subscribe(this.onObjectsRow.bind(this));
     this.coreData.getTableEntry('ComponentsRegistry', id).subscribe(this.onObjectComponents.bind(this));
   }
 
@@ -26,23 +21,10 @@ export class ItemDirective extends TooltipDirective {
     renderer: Renderer2,
     injector: Injector,
     environmentInjector: EnvironmentInjector,
-    private coreData: LuCoreDataService,
+    protected coreData: LuCoreDataService,
     private slotComponent: SlotComponent
   ) {
-    super(element, applicationRef, renderer, injector);
-
-    this.itemTooltipRef = createComponent(ItemTooltipComponent, { environmentInjector });
-    this.content = this.itemTooltipRef;
-  }
-
-  onObjectsRow(object: DB_Objects) {
-    console.log(object);
-    if (object.displayName) {
-      this.itemTooltipRef.instance.title = object.displayName;
-    } else if (object.name) {
-      this.itemTooltipRef.instance.title = object.name;
-    }
-    this.itemTooltipRef.changeDetectorRef.detectChanges();
+    super(element, applicationRef, renderer, injector, environmentInjector, coreData);
   }
 
   onObjectComponents(components: DB_ComponentsRegistry[]) {


### PR DESCRIPTION
ItemDirective both fetches slot content as well as adds a tooltip. When slot content is set by a bulk request, fetching slot data is unnecessary, but the tooltip is still wanted - thus, this is now split out into ItemTooltipDirective, with ItemDirective adding the slot fetching on top.