### PR TITLE
Fix chat bubble scaling on Safari

### DIFF
--- a/src/assets/ui/chat-bubble.svg
+++ b/src/assets/ui/chat-bubble.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" height="67.8px" width="176.2px" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" height="67.8px" width="176.2px" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
   <g>
     <path d="M 176.2 0 L 176.2 67.8 L 0 67.8 L 0 0 Z" fill="url(#gradient0)" fill-rule="evenodd" stroke="none"/>
     <path d="M 176.2 67.8 L 0 67.8 L 0 28.3 Q 40.2 32.5 92.5 32.5 Q 139.2 32.5 176.2 29.15 Z" fill="#ea6102" fill-rule="evenodd" stroke="none"/>


### PR DESCRIPTION
Turns out safari sets SVGs to fixed aspect ratios by default if not overridden, while all other browsers set the default to variable aspect ratio. This explicitly sets chat bubble aspect ratio to variable.