### PR TITLE
Add GraphQL infrastructure

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -1,0 +1,18 @@
+import type { CodegenConfig } from "@graphql-codegen/cli";
+
+const config: CodegenConfig = {
+  overwrite: true,
+  schema: "schema.graphql",
+  documents: "src/**/*.graphql",
+  generates: {
+    "src/generated/graphql.ts": {
+      plugins: ["typescript", "typescript-operations", "typescript-apollo-angular"],
+      config: {
+        gqlImport: "app/util/services/graphql#gql",
+        apolloAngularPackage: "app/util/services/graphql"
+      }
+    }
+  }
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,8 @@
         "@angular/cli": "15.0.4",
         "@angular/compiler-cli": "15.0.4",
         "@angular/language-service": "15.0.4",
+        "@graphql-codegen/cli": "5.0.2",
+        "@graphql-codegen/typescript-apollo-angular": "4.0.0",
         "@types/jasmine": "^3.6.9",
         "@types/jasminewd2": "^2.0.8",
         "@types/node": "^12.20.7",
@@ -47,7 +49,7 @@
         "protractor": "~7.0.0",
         "ts-node": "~4.1.0",
         "tslint": "~6.1.0",
-        "typescript": "4.8.4"
+        "typescript": "^4.8.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -665,28 +667,216 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
+    "node_modules/@ardatan/relay-compiler": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz",
+      "integrity": "sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.14.0",
+        "@babel/generator": "^7.14.0",
+        "@babel/parser": "^7.14.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.0.0",
+        "babel-preset-fbjs": "^3.4.0",
+        "chalk": "^4.0.0",
+        "fb-watchman": "^2.0.0",
+        "fbjs": "^3.0.0",
+        "glob": "^7.1.1",
+        "immutable": "~3.7.6",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "relay-runtime": "12.0.0",
+        "signedsource": "^1.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "relay-compiler": "bin/relay-compiler"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/immutable": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "integrity": "sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@ardatan/sync-fetch": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
+      "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@assemblyscript/loader": {
       "version": "0.10.1",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.3.tgz",
-      "integrity": "sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+      "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -768,22 +958,51 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz",
-      "integrity": "sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+      "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.0",
-        "@babel/helper-validator-option": "^7.21.0",
-        "browserslist": "^4.21.3",
+        "@babel/compat-data": "^7.24.7",
+        "@babel/helper-validator-option": "^7.24.7",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/browserslist": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001629",
+        "electron-to-chromium": "^1.4.796",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.16"
       },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
@@ -796,9 +1015,10 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -869,10 +1089,13 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
       "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -889,39 +1112,39 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name/node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -939,45 +1162,44 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
-      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.4"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz",
-      "integrity": "sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+      "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.1",
-        "@babel/helper-module-imports": "^7.21.4",
-        "@babel/helper-simple-access": "^7.21.5",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.0"
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-simple-access": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/template": {
-      "version": "7.21.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.21.9.tgz",
-      "integrity": "sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==",
+    "node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "@babel/parser": "^7.21.9",
-        "@babel/types": "^7.21.5"
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -995,9 +1217,10 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.20.2",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+      "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1035,12 +1258,13 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz",
-      "integrity": "sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.5"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1069,27 +1293,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
-      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -1110,51 +1334,51 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.3.tgz",
-      "integrity": "sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+      "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.3"
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers/node_modules/@babel/template": {
-      "version": "7.21.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.21.9.tgz",
-      "integrity": "sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "@babel/parser": "^7.21.9",
-        "@babel/types": "^7.21.5"
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1486,6 +1710,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.7.tgz",
+      "integrity": "sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.20.0",
       "dev": true,
@@ -1506,6 +1745,21 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+      "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1758,6 +2012,22 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.7.tgz",
+      "integrity": "sha512-cjRKJ7FobOH2eakx7Ja+KpJRj8+y+/SiB3ooYm/n2UJfxu0oEaOoxOinitkJcPqv9KxS0kxTGPUaR7L2XcXDXA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/plugin-syntax-flow": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-for-of": {
       "version": "7.18.8",
       "dev": true,
@@ -1949,6 +2219,52 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.7.tgz",
+      "integrity": "sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
+      "integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.24.7",
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/plugin-syntax-jsx": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+      "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
@@ -2245,20 +2561,20 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.24.7",
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-function-name": "^7.24.7",
+        "@babel/helper-hoist-variables": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -2266,14 +2582,14 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.24.7",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -2281,25 +2597,25 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -2679,6 +2995,1665 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@graphql-codegen/add": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-5.0.2.tgz",
+      "integrity": "sha512-ouBkSvMFUhda5VoKumo/ZvsZM9P5ZTyDsI8LW18VxSNWOjrTeLXBWHG8Gfaai0HwhflPtCYVABbriEcOmrRShQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/add/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/cli": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-5.0.2.tgz",
+      "integrity": "sha512-MBIaFqDiLKuO4ojN6xxG9/xL9wmfD3ZjZ7RsPjwQnSHBCUXnEkdKvX+JVpx87Pq29Ycn8wTJUguXnTZ7Di0Mlw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.18.13",
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.18.13",
+        "@graphql-codegen/client-preset": "^4.2.2",
+        "@graphql-codegen/core": "^4.0.2",
+        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "@graphql-tools/apollo-engine-loader": "^8.0.0",
+        "@graphql-tools/code-file-loader": "^8.0.0",
+        "@graphql-tools/git-loader": "^8.0.0",
+        "@graphql-tools/github-loader": "^8.0.0",
+        "@graphql-tools/graphql-file-loader": "^8.0.0",
+        "@graphql-tools/json-file-loader": "^8.0.0",
+        "@graphql-tools/load": "^8.0.0",
+        "@graphql-tools/prisma-loader": "^8.0.0",
+        "@graphql-tools/url-loader": "^8.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "@whatwg-node/fetch": "^0.8.0",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^8.1.3",
+        "debounce": "^1.2.0",
+        "detect-indent": "^6.0.0",
+        "graphql-config": "^5.0.2",
+        "inquirer": "^8.0.0",
+        "is-glob": "^4.0.1",
+        "jiti": "^1.17.1",
+        "json-to-pretty-yaml": "^1.2.2",
+        "listr2": "^4.0.5",
+        "log-symbols": "^4.0.0",
+        "micromatch": "^4.0.5",
+        "shell-quote": "^1.7.3",
+        "string-env-interpolation": "^1.0.1",
+        "ts-log": "^2.2.3",
+        "tslib": "^2.4.0",
+        "yaml": "^2.3.1",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "gql-gen": "cjs/bin.js",
+        "graphql-code-generator": "cjs/bin.js",
+        "graphql-codegen": "cjs/bin.js",
+        "graphql-codegen-esm": "esm/bin.js"
+      },
+      "peerDependencies": {
+        "@parcel/watcher": "^2.1.0",
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@parcel/watcher": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@graphql-codegen/cli/node_modules/yaml": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-4.2.6.tgz",
+      "integrity": "sha512-e7SzPb+nxNJfsD0uG+NSyzIeTtCXTouX5VThmcCoqGMDLgF5Lo7932B3HtZCvzmzqcXxRjJ81CmkA2LhlqIbCw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/template": "^7.20.7",
+        "@graphql-codegen/add": "^5.0.2",
+        "@graphql-codegen/gql-tag-operations": "4.0.7",
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/typed-document-node": "^5.0.7",
+        "@graphql-codegen/typescript": "^4.0.7",
+        "@graphql-codegen/typescript-operations": "^4.2.1",
+        "@graphql-codegen/visitor-plugin-common": "^5.2.0",
+        "@graphql-tools/documents": "^1.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "@graphql-typed-document-node/core": "3.2.0",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-IZbpkhwVqgizcjNiaVzNAzm/xbWT6YnGgeOLwVjm4KbJn3V2jchVtuzHH09G5/WkkLSk2wgbXNdwjM41JxO6Eg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "@graphql-tools/schema": "^10.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/core/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/gql-tag-operations/-/gql-tag-operations-4.0.7.tgz",
+      "integrity": "sha512-2I69+IDC8pqAohH6cgKse/vPfJ/4TRTJX96PkAKz8S4RD54PUHtBmzCdBInIFEP/vQuH5mFUAaIKXXjznmGOsg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/visitor-plugin-common": "5.2.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/gql-tag-operations/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.0.4.tgz",
+      "integrity": "sha512-MOIuHFNWUnFnqVmiXtrI+4UziMTYrcquljaI5f/T/Bc7oO7sXcfkAvgkNWEEi9xWreYwvuer3VHCuPI/lAFWbw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/schema-ast": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-4.0.2.tgz",
+      "integrity": "sha512-5mVAOQQK3Oz7EtMl/l3vOQdc2aYClUzVDHHkMvZlunc+KlGgl81j8TLa+X7ANIllqU4fUEsQU3lJmk4hXP6K7Q==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "@graphql-tools/utils": "^10.0.0",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/schema-ast/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typed-document-node": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-5.0.7.tgz",
+      "integrity": "sha512-rgFh96hAbNwPUxLVlRcNhGaw2+y7ZGx7giuETtdO8XzPasTQGWGRkZ3wXQ5UUiTX4X3eLmjnuoXYKT7HoxSznQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/visitor-plugin-common": "5.2.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typed-document-node/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typescript": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-4.0.7.tgz",
+      "integrity": "sha512-Gn+JNvQBJhBqH7s83piAJ6UeU/MTj9GXWFO9bdbl8PMLCAM1uFAtg04iHfkGCtDKXcUg5a3Dt/SZG85uk5KuhA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/schema-ast": "^4.0.2",
+        "@graphql-codegen/visitor-plugin-common": "5.2.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-apollo-angular/-/typescript-apollo-angular-4.0.0.tgz",
+      "integrity": "sha512-uZQGvZBXJrgJ+9KKeRrKcB8wHCsailJ1WaCizNLf2YsTBUELVX0SQRrSFptAul9qYzsS84LRs6ndJsmSUnER6w==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^3.0.0",
+        "@graphql-codegen/visitor-plugin-common": "2.13.1",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "tslib": "~2.6.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+      "integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^9.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz",
+      "integrity": "sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^2.7.2",
+        "@graphql-tools/optimize": "^1.3.0",
+        "@graphql-tools/relay-operation-optimizer": "^6.5.0",
+        "@graphql-tools/utils": "^8.8.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.14",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz",
+      "integrity": "sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^8.8.0",
+        "change-case-all": "1.0.14",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
+      "integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/change-case-all": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+      "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+      "dev": true,
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-tools/optimize": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.4.0.tgz",
+      "integrity": "sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-tools/relay-operation-optimizer": {
+      "version": "6.5.18",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz",
+      "integrity": "sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/relay-compiler": "12.0.0",
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/@graphql-tools/utils": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-apollo-angular/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typescript-operations": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-4.2.1.tgz",
+      "integrity": "sha512-LhEPsaP+AI65zfK2j6CBAL4RT0bJL/rR9oRWlvwtHLX0t7YQr4CP4BXgvvej9brYdedAxHGPWeV1tPHy5/z9KQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/typescript": "^4.0.7",
+        "@graphql-codegen/visitor-plugin-common": "5.2.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.2.0.tgz",
+      "integrity": "sha512-0p8AwmARaZCAlDFfQu6Sz+JV6SjbPDx3y2nNM7WAAf0au7Im/GpJ7Ke3xaIYBc1b2rTZ+DqSTJI/zomENGD9NA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.1.tgz",
+      "integrity": "sha512-NaPeVjtrfbPXcl+MLQCJLWtqe2/E4bbAqcauEOQ+3sizw1Fc2CNmhHRF8a6W4D0ekvTRRXAMptXYgA2uConbrA==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/sync-fetch": "^0.0.1",
+        "@graphql-tools/utils": "^10.0.13",
+        "@whatwg-node/fetch": "^0.9.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/fetch": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+      "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+      "dev": true,
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.5.7",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/node-fetch": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+      "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+      "dev": true,
+      "dependencies": {
+        "@kamilkisiela/fast-url-parser": "^1.1.4",
+        "@whatwg-node/events": "^0.1.0",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/apollo-engine-loader/node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/batch-execute": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.4.tgz",
+      "integrity": "sha512-kkebDLXgDrep5Y0gK1RN3DMUlLqNhg60OAz0lTCqrYeja6DshxLtLkj+zV4mVbBA4mQOEoBmw6g1LZs3dA84/w==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.13",
+        "dataloader": "^2.2.2",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/code-file-loader": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.2.tgz",
+      "integrity": "sha512-GrLzwl1QV2PT4X4TEEfuTmZYzIZHLqoTGBjczdUzSqgCCcqwWzLB3qrJxFQfI8e5s1qZ1bhpsO9NoMn7tvpmyA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/graphql-tag-pluck": "8.3.1",
+        "@graphql-tools/utils": "^10.0.13",
+        "globby": "^11.0.3",
+        "tslib": "^2.4.0",
+        "unixify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/code-file-loader/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-tools/code-file-loader/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-tools/delegate": {
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.11.tgz",
+      "integrity": "sha512-+sKeecdIVXhFB/66e5yjeKYZ3Lpn52yNG637ElVhciuLGgFc153rC6l6zcuNd9yx5wMrNx35U/h3HsMIEI3xNw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/batch-execute": "^9.0.4",
+        "@graphql-tools/executor": "^1.2.1",
+        "@graphql-tools/schema": "^10.0.4",
+        "@graphql-tools/utils": "^10.2.1",
+        "dataloader": "^2.2.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/documents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/documents/-/documents-1.0.1.tgz",
+      "integrity": "sha512-aweoMH15wNJ8g7b2r4C4WRuJxZ0ca8HtNO54rkye/3duxTkW4fGBEutCx03jCIr5+a1l+4vFJNP859QnAVBVCA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.6.tgz",
+      "integrity": "sha512-+1kjfqzM5T2R+dCw7F4vdJ3CqG+fY/LYJyhNiWEFtq0ToLwYzR/KKyD8YuzTirEjSxWTVlcBh7endkx5n5F6ew==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^10.1.1",
+        "@graphql-typed-document-node/core": "3.2.0",
+        "@repeaterjs/repeater": "^3.0.4",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-graphql-ws": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.1.2.tgz",
+      "integrity": "sha512-+9ZK0rychTH1LUv4iZqJ4ESbmULJMTsv3XlFooPUngpxZkk00q6LqHKJRrsLErmQrVaC7cwQCaRBJa0teK17Lg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.13",
+        "@types/ws": "^8.0.0",
+        "graphql-ws": "^5.14.0",
+        "isomorphic-ws": "^5.0.0",
+        "tslib": "^2.4.0",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-graphql-ws/node_modules/ws": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@graphql-tools/executor-http": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.9.tgz",
+      "integrity": "sha512-+NXaZd2MWbbrWHqU4EhXcrDbogeiCDmEbrAN+rMn4Nu2okDjn2MTFDbTIab87oEubQCH4Te1wDkWPKrzXup7+Q==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.13",
+        "@repeaterjs/repeater": "^3.0.4",
+        "@whatwg-node/fetch": "^0.9.0",
+        "extract-files": "^11.0.0",
+        "meros": "^1.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-http/node_modules/@types/node": {
+      "version": "20.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/fetch": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+      "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+      "dev": true,
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.5.7",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/node-fetch": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+      "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+      "dev": true,
+      "dependencies": {
+        "@kamilkisiela/fast-url-parser": "^1.1.4",
+        "@whatwg-node/events": "^0.1.0",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-http/node_modules/meros": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
+      "integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=13"
+      },
+      "peerDependencies": {
+        "@types/node": ">=13"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@graphql-tools/executor-http/node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/executor-legacy-ws": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.6.tgz",
+      "integrity": "sha512-lDSxz9VyyquOrvSuCCnld3256Hmd+QI2lkmkEv7d4mdzkxkK4ddAWW1geQiWrQvWmdsmcnGGlZ7gDGbhEExwqg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.13",
+        "@types/ws": "^8.0.0",
+        "isomorphic-ws": "^5.0.0",
+        "tslib": "^2.4.0",
+        "ws": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-legacy-ws/node_modules/ws": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@graphql-tools/git-loader": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.6.tgz",
+      "integrity": "sha512-FQFO4H5wHAmHVyuUQrjvPE8re3qJXt50TWHuzrK3dEaief7JosmlnkLMDMbMBwtwITz9u1Wpl6doPhT2GwKtlw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/graphql-tag-pluck": "8.3.1",
+        "@graphql-tools/utils": "^10.0.13",
+        "is-glob": "4.0.3",
+        "micromatch": "^4.0.4",
+        "tslib": "^2.4.0",
+        "unixify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/github-loader": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-8.0.1.tgz",
+      "integrity": "sha512-W4dFLQJ5GtKGltvh/u1apWRFKBQOsDzFxO9cJkOYZj1VzHCpRF43uLST4VbCfWve+AwBqOuKr7YgkHoxpRMkcg==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/sync-fetch": "^0.0.1",
+        "@graphql-tools/executor-http": "^1.0.9",
+        "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+        "@graphql-tools/utils": "^10.0.13",
+        "@whatwg-node/fetch": "^0.9.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/github-loader/node_modules/@whatwg-node/events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/github-loader/node_modules/@whatwg-node/fetch": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+      "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+      "dev": true,
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.5.7",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/github-loader/node_modules/@whatwg-node/node-fetch": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+      "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+      "dev": true,
+      "dependencies": {
+        "@kamilkisiela/fast-url-parser": "^1.1.4",
+        "@whatwg-node/events": "^0.1.0",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/github-loader/node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/graphql-file-loader": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.1.tgz",
+      "integrity": "sha512-7gswMqWBabTSmqbaNyWSmRRpStWlcCkBc73E6NZNlh4YNuiyKOwbvSkOUYFOqFMfEL+cFsXgAvr87Vz4XrYSbA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/import": "7.0.1",
+        "@graphql-tools/utils": "^10.0.13",
+        "globby": "^11.0.3",
+        "tslib": "^2.4.0",
+        "unixify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-file-loader/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-file-loader/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-tag-pluck": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.1.tgz",
+      "integrity": "sha512-ujits9tMqtWQQq4FI4+qnVPpJvSEn7ogKtyN/gfNT+ErIn6z1e4gyVGQpTK5sgAUXq1lW4gU/5fkFFC5/sL2rQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.22.9",
+        "@babel/parser": "^7.16.8",
+        "@babel/plugin-syntax-import-assertions": "^7.20.0",
+        "@babel/traverse": "^7.16.8",
+        "@babel/types": "^7.16.8",
+        "@graphql-tools/utils": "^10.0.13",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@babel/core": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+      "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.24.7",
+        "@babel/helper-compilation-targets": "^7.24.7",
+        "@babel/helper-module-transforms": "^7.24.7",
+        "@babel/helpers": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/template": "^7.24.7",
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@babel/generator": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.24.7",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@babel/template": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@graphql-tools/import": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.1.tgz",
+      "integrity": "sha512-935uAjAS8UAeXThqHfYVr4HEAp6nHJ2sximZKO1RzUTq5WoALMAhhGARl0+ecm6X+cqNUwIChJbjtaa6P/ML0w==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.13",
+        "resolve-from": "5.0.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/json-file-loader": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.1.tgz",
+      "integrity": "sha512-lAy2VqxDAHjVyqeJonCP6TUemrpYdDuKt25a10X6zY2Yn3iFYGnuIDQ64cv3ytyGY6KPyPB+Kp+ZfOkNDG3FQA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.13",
+        "globby": "^11.0.3",
+        "tslib": "^2.4.0",
+        "unixify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/json-file-loader/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-tools/json-file-loader/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-tools/load": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.2.tgz",
+      "integrity": "sha512-S+E/cmyVmJ3CuCNfDuNF2EyovTwdWfQScXv/2gmvJOti2rGD8jTt9GYVzXaxhblLivQR9sBUCNZu/w7j7aXUCA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/schema": "^10.0.3",
+        "@graphql-tools/utils": "^10.0.13",
+        "p-limit": "3.1.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.4.tgz",
+      "integrity": "sha512-MivbDLUQ+4Q8G/Hp/9V72hbn810IJDEZQ57F01sHnlrrijyadibfVhaQfW/pNH+9T/l8ySZpaR/DpL5i+ruZ+g==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.13",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/optimize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-2.0.0.tgz",
+      "integrity": "sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.4.tgz",
+      "integrity": "sha512-hqKPlw8bOu/GRqtYr0+dINAI13HinTVYBDqhwGAPIFmLr5s+qKskzgCiwbsckdrb5LWVFmVZc+UXn80OGiyBzg==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/url-loader": "^8.0.2",
+        "@graphql-tools/utils": "^10.0.13",
+        "@types/js-yaml": "^4.0.0",
+        "@whatwg-node/fetch": "^0.9.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.1",
+        "dotenv": "^16.0.0",
+        "graphql-request": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "jose": "^5.0.0",
+        "js-yaml": "^4.0.0",
+        "lodash": "^4.17.20",
+        "scuid": "^1.1.0",
+        "tslib": "^2.4.0",
+        "yaml-ast-parser": "^0.0.43"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/@whatwg-node/events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/@whatwg-node/fetch": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+      "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+      "dev": true,
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.5.7",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/@whatwg-node/node-fetch": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+      "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+      "dev": true,
+      "dependencies": {
+        "@kamilkisiela/fast-url-parser": "^1.1.4",
+        "@whatwg-node/events": "^0.1.0",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/relay-operation-optimizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.1.tgz",
+      "integrity": "sha512-y0ZrQ/iyqWZlsS/xrJfSir3TbVYJTYmMOu4TaSz6F4FRDTQ3ie43BlKkhf04rC28pnUOS4BO9pDcAo1D30l5+A==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/relay-compiler": "12.0.0",
+        "@graphql-tools/utils": "^10.0.13",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.4.tgz",
+      "integrity": "sha512-HuIwqbKxPaJujox25Ra4qwz0uQzlpsaBOzO6CVfzB/MemZdd+Gib8AIvfhQArK0YIN40aDran/yi+E5Xf0mQww==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/merge": "^9.0.3",
+        "@graphql-tools/utils": "^10.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.2.tgz",
+      "integrity": "sha512-1dKp2K8UuFn7DFo1qX5c1cyazQv2h2ICwA9esHblEqCYrgf69Nk8N7SODmsfWg94OEaI74IqMoM12t7eIGwFzQ==",
+      "dev": true,
+      "dependencies": {
+        "@ardatan/sync-fetch": "^0.0.1",
+        "@graphql-tools/delegate": "^10.0.4",
+        "@graphql-tools/executor-graphql-ws": "^1.1.2",
+        "@graphql-tools/executor-http": "^1.0.9",
+        "@graphql-tools/executor-legacy-ws": "^1.0.6",
+        "@graphql-tools/utils": "^10.0.13",
+        "@graphql-tools/wrap": "^10.0.2",
+        "@types/ws": "^8.0.0",
+        "@whatwg-node/fetch": "^0.9.0",
+        "isomorphic-ws": "^5.0.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.11",
+        "ws": "^8.12.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/fetch": {
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+      "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+      "dev": true,
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.5.7",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/node-fetch": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+      "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+      "dev": true,
+      "dependencies": {
+        "@kamilkisiela/fast-url-parser": "^1.1.4",
+        "@whatwg-node/events": "^0.1.0",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/ws": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.2.1.tgz",
+      "integrity": "sha512-U8OMdkkEt3Vp3uYHU2pMc6mwId7axVAcSSmcqJcUmWNPqY2pfee5O655ybTI2kNPWAe58Zu6gLu4Oi4QT4BgWA==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-inspect": "1.0.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/wrap": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.5.tgz",
+      "integrity": "sha512-Cbr5aYjr3HkwdPvetZp1cpDWTGdD1Owgsb3z/ClzhmrboiK86EnQDxDvOJiQkDCPWE9lNBwj8Y4HfxroY0D9DQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/delegate": "^10.0.4",
+        "@graphql-tools/schema": "^10.0.3",
+        "@graphql-tools/utils": "^10.1.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "dev": true,
@@ -2703,22 +4678,24 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2738,13 +4715,13 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/resolve-uri": {
@@ -2754,6 +4731,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@kamilkisiela/fast-url-parser": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz",
+      "integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
+      "dev": true
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -2958,6 +4941,63 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
+      "dev": true,
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
+      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/@repeaterjs/repeater": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
+      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+      "dev": true
+    },
     "node_modules/@schematics/angular": {
       "version": "15.0.4",
       "dev": true,
@@ -3119,6 +5159,12 @@
       "dependencies": {
         "@types/jasmine": "*"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -3374,6 +5420,38 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@whatwg-node/events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
+      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==",
+      "dev": true
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
+      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "@whatwg-node/node-fetch": "^0.3.6",
+        "busboy": "^1.6.0",
+        "urlpattern-polyfill": "^8.0.0",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
+      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
+      "dev": true,
+      "dependencies": {
+        "@whatwg-node/events": "^0.0.3",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "fast-url-parser": "^1.1.3",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -3671,6 +5749,15 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/array-uniq": {
       "version": "1.0.3",
       "dev": true,
@@ -3687,12 +5774,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dev": true,
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assert-plus": {
@@ -3708,10 +5815,31 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.13",
@@ -3840,6 +5968,50 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-syntax-trailing-function-commas": {
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
+      "dev": true
+    },
+    "node_modules/babel-preset-fbjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+      "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-class-properties": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-property-literals": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4068,6 +6240,15 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "dev": true,
@@ -4110,6 +6291,18 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -4241,6 +6434,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "dev": true,
@@ -4250,9 +6453,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001494",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz",
-      "integrity": "sha512-sY2B5Qyl46ZzfYDegrl8GBCzdawSLT4ThM9b9F+aDYUrAG2zCOyMbd2Tq34mS1g4ZKBfjRlzOohQMxx28x6wJg==",
+      "version": "1.0.30001629",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz",
+      "integrity": "sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==",
       "dev": true,
       "funding": [
         {
@@ -4268,6 +6471,17 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -4285,6 +6499,44 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/change-case-all": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
+      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+      "dev": true,
+      "dependencies": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
       }
     },
     "node_modules/chardet": {
@@ -4359,6 +6611,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4516,6 +6784,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -4621,6 +6898,17 @@
       "version": "1.1.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -4859,6 +7147,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-inspect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.0.tgz",
+      "integrity": "sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4988,6 +7297,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
+      "dev": true
+    },
     "node_modules/date-format": {
       "version": "4.0.13",
       "dev": true,
@@ -4995,6 +7310,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -5144,6 +7465,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -5248,6 +7578,37 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "dev": true,
@@ -5263,9 +7624,10 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.284",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.4.796",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.796.tgz",
+      "integrity": "sha512-NglN/xprcM+SHD2XCli4oC6bWe6kHoytcyLKCWXmRL854F0qhPhaYgUswUsglnPxYaNQIg2uMY4BvaomIf3kLA==",
+      "dev": true
     },
     "node_modules/emitter-component": {
       "version": "1.1.1"
@@ -5470,9 +7832,10 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -5737,6 +8100,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/extract-files": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "dev": true,
@@ -5744,6 +8119,12 @@
         "node >=0.6.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5770,6 +8151,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dev": true,
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-url-parser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true
+    },
     "node_modules/fastparse": {
       "version": "1.1.2",
       "dev": true,
@@ -5793,6 +8198,59 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fbjs": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+      "dev": true,
+      "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^1.0.35"
+      }
+    },
+    "node_modules/fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
+    },
+    "node_modules/fbjs/node_modules/ua-parser-js": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz",
+      "integrity": "sha512-Aq5ppTOfvrCMgAPneW1HfWj66Xi7XL+/mIy996R1/CLS/rcyJQm6QZdsKrUeivDFQ+Oc9Wyuwor8Ze8peEoUoQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/figures": {
@@ -6151,6 +8609,161 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-config": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.3.tgz",
+      "integrity": "sha512-BNGZaoxIBkv9yy6Y7omvsaBUHOzfFcII3UN++tpH8MGOKFPFkCPZuwx09ggANMt8FgyWP1Od8SWPmrUEZca4NQ==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-tools/graphql-file-loader": "^8.0.0",
+        "@graphql-tools/json-file-loader": "^8.0.0",
+        "@graphql-tools/load": "^8.0.0",
+        "@graphql-tools/merge": "^9.0.0",
+        "@graphql-tools/url-loader": "^8.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "cosmiconfig": "^8.1.0",
+        "jiti": "^1.18.2",
+        "minimatch": "^4.2.3",
+        "string-env-interpolation": "^1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "cosmiconfig-toml-loader": "^1.0.0",
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "cosmiconfig-toml-loader": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/graphql-config/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/graphql-config/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/graphql-config/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/graphql-config/node_modules/minimatch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
+      "integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/graphql-config/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.0.tgz",
+      "integrity": "sha512-Ju2RCU2dQMgSKtArPbEtsK5gNLnsQyTNIo/T7cZNp96niC1x0KdJNZV0TIoilceBPQwfb5itrGl8pkFeOUMl4A==",
+      "dev": true,
+      "workspaces": [
+        "website"
+      ],
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
     "node_modules/hammerjs": {
       "version": "2.0.8",
       "license": "MIT",
@@ -6272,6 +8885,16 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dev": true,
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -6620,6 +9243,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
@@ -6760,6 +9395,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
@@ -6773,6 +9417,19 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "dependencies": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-arrayish": {
@@ -6857,6 +9514,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+      "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "dev": true,
@@ -6918,6 +9584,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "dependencies": {
+        "is-unc-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -6935,6 +9613,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "dependencies": {
+        "unc-path-regex": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "dev": true,
@@ -6946,10 +9636,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+      "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/is-what": {
       "version": "3.14.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -6989,6 +9697,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "dev": true,
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/isstream": {
@@ -7215,6 +9932,24 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.3.tgz",
+      "integrity": "sha512-uy2bNX5zQ+tESe+TiC7ilGRz8AtRGmnJH55NC5S0nSUjvvvM2hJHmefHErugGXN4pNv4Qx7vLsnNw9qJ9mtIsw==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.4.0.tgz",
+      "integrity": "sha512-6rpxTHPAQyWMb9A35BroFl1Sp0ST3DpPcm5EVIxZxdH+e0Hv9fwhyB3XLKFUcHNpdSDnETmBfuPPTTlYz5+USw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7268,6 +10003,19 @@
       "version": "5.0.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/json-to-pretty-yaml": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
+      "integrity": "sha512-rvm6hunfCcqegwYaG5T4yKJWxc9FXFgBVrcTZ4XfSVRwa5HA/Xs+vB/Eo9treYYHCeNM0nrSUr82V/M31Urc7A==",
+      "dev": true,
+      "dependencies": {
+        "remedial": "^1.0.7",
+        "remove-trailing-spaces": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7646,6 +10394,42 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/listr2": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.5",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/listr2/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "dev": true,
@@ -7682,6 +10466,12 @@
       "version": "4.0.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -7762,6 +10552,88 @@
         "node": ">=8"
       }
     },
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-update/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/log4js": {
       "version": "6.6.1",
       "dev": true,
@@ -7775,6 +10647,36 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/lower-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+      "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/lru-cache": {
@@ -7968,6 +10870,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/media-typer": {
@@ -8325,11 +11236,41 @@
         "node-gyp-build": "^4.2.2"
       }
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -8388,10 +11329,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true
+    },
     "node_modules/node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "node_modules/nopt": {
@@ -8737,6 +11684,12 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
+    },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "dev": true,
@@ -8919,6 +11872,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-locate": {
       "version": "4.1.0",
       "dev": true,
@@ -9075,6 +12043,16 @@
       "dev": true,
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9085,6 +12063,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/parse-json": {
@@ -9216,6 +12208,26 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -9251,6 +12263,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+      "dev": true,
+      "dependencies": {
+        "path-root-regex": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -9271,9 +12304,10 @@
       "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -9483,6 +12517,15 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -9773,6 +12816,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/q": {
       "version": "1.4.1",
       "dev": true,
@@ -10034,6 +13101,38 @@
       "bin": {
         "jsesc": "bin/jsesc"
       }
+    },
+    "node_modules/relay-runtime": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
+      "integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "fbjs": "^3.0.0",
+        "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/remedial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true
+    },
+    "node_modules/remove-trailing-spaces": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz",
+      "integrity": "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==",
+      "dev": true
     },
     "node_modules/request": {
       "version": "2.88.2",
@@ -10387,6 +13486,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/scuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/scuid/-/scuid-1.1.0.tgz",
+      "integrity": "sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==",
+      "dev": true
+    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -10538,6 +13643,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "dev": true,
@@ -10677,6 +13793,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "dev": true,
@@ -10695,6 +13820,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signedsource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+      "integrity": "sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==",
+      "dev": true
+    },
     "node_modules/slash": {
       "version": "4.0.0",
       "dev": true,
@@ -10706,6 +13837,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "dev": true,
@@ -10713,6 +13891,16 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/socket.io": {
@@ -10918,6 +14106,15 @@
         "wbuf": "^1.7.3"
       }
     },
+    "node_modules/sponge-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.2",
       "dev": true,
@@ -10990,6 +14187,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "dev": true,
@@ -11016,6 +14222,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/string-env-interpolation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+      "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -11086,6 +14298,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swap-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/symbol-observable": {
@@ -11256,6 +14477,15 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "node_modules/title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "dev": true,
@@ -11306,6 +14536,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "dev": true,
@@ -11313,6 +14549,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-log": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.5.tgz",
+      "integrity": "sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==",
+      "dev": true
     },
     "node_modules/ts-node": {
       "version": "4.1.0",
@@ -11492,8 +14734,9 @@
     },
     "node_modules/typescript": {
       "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11520,6 +14763,23 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -11587,6 +14847,30 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unixify/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+      "dev": true,
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "dev": true,
@@ -11596,7 +14880,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
       "dev": true,
       "funding": [
         {
@@ -11606,18 +14892,39 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/uri-js": {
@@ -11627,6 +14934,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -11679,6 +14992,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/value-or-promise": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/vary": {
@@ -11750,6 +15072,34 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.0.tgz",
+      "integrity": "sha512-kR1UQNH8MD42CYuLzvibfakG5Ew5seG85dMMoAM/1LqvckxaF6pUiidLuraIu4V+YCIFabYecUZAW0TuxAoaqw==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/webcrypto-core/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
     },
     "node_modules/webdriver-js-extender": {
       "version": "2.1.0",
@@ -11861,6 +15211,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/webpack": {
       "version": "5.76.1",
@@ -12123,6 +15479,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "1.3.1",
       "dev": true,
@@ -12266,6 +15632,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true
+    },
     "node_modules/yargs": {
       "version": "17.6.2",
       "dev": true,
@@ -12310,6 +15682,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zone.js": {
@@ -12683,24 +16067,172 @@
         "tslib": "^2.3.0"
       }
     },
+    "@ardatan/relay-compiler": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz",
+      "integrity": "sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.14.0",
+        "@babel/generator": "^7.14.0",
+        "@babel/parser": "^7.14.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.0.0",
+        "babel-preset-fbjs": "^3.4.0",
+        "chalk": "^4.0.0",
+        "fb-watchman": "^2.0.0",
+        "fbjs": "^3.0.0",
+        "glob": "^7.1.1",
+        "immutable": "~3.7.6",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "relay-runtime": "12.0.0",
+        "signedsource": "^1.0.0",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "immutable": {
+          "version": "3.7.6",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+          "integrity": "sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "@ardatan/sync-fetch": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
+      "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.1"
+      }
+    },
     "@assemblyscript/loader": {
       "version": "0.10.1",
       "dev": true
     },
     "@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
       }
     },
     "@babel/compat-data": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.3.tgz",
-      "integrity": "sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+      "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
       "dev": true
     },
     "@babel/core": {
@@ -12759,18 +16291,30 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.22.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz",
-      "integrity": "sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+      "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.22.0",
-        "@babel/helper-validator-option": "^7.21.0",
-        "browserslist": "^4.21.3",
+        "@babel/compat-data": "^7.24.7",
+        "@babel/helper-validator-option": "^7.24.7",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "dependencies": {
+        "browserslist": {
+          "version": "4.23.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+          "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001629",
+            "electron-to-chromium": "^1.4.796",
+            "node-releases": "^2.0.14",
+            "update-browserslist-db": "^1.0.16"
+          }
+        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -12781,7 +16325,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         },
         "yallist": {
@@ -12832,10 +16378,13 @@
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.24.7"
+      }
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.18.6",
@@ -12845,35 +16394,35 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "dependencies": {
         "@babel/template": {
-          "version": "7.22.15",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-          "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+          "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.22.13",
-            "@babel/parser": "^7.22.15",
-            "@babel/types": "^7.22.15"
+            "@babel/code-frame": "^7.24.7",
+            "@babel/parser": "^7.24.7",
+            "@babel/types": "^7.24.7"
           }
         }
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.7"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -12884,39 +16433,35 @@
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
-      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.21.4"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.22.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz",
-      "integrity": "sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+      "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.22.1",
-        "@babel/helper-module-imports": "^7.21.4",
-        "@babel/helper-simple-access": "^7.21.5",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.0"
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-simple-access": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7"
       },
       "dependencies": {
-        "@babel/template": {
-          "version": "7.21.9",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.21.9.tgz",
-          "integrity": "sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==",
+        "@babel/helper-split-export-declaration": {
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+          "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.21.4",
-            "@babel/parser": "^7.21.9",
-            "@babel/types": "^7.21.5"
+            "@babel/types": "^7.24.7"
           }
         }
       }
@@ -12929,7 +16474,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.20.2",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+      "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
@@ -12954,12 +16501,13 @@
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz",
-      "integrity": "sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.21.5"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -12977,21 +16525,21 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
-      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
       "dev": true
     },
     "@babel/helper-wrap-function": {
@@ -13005,44 +16553,44 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.3.tgz",
-      "integrity": "sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+      "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.21.9",
-        "@babel/traverse": "^7.22.1",
-        "@babel/types": "^7.22.3"
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "dependencies": {
         "@babel/template": {
-          "version": "7.21.9",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.21.9.tgz",
-          "integrity": "sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==",
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+          "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.21.4",
-            "@babel/parser": "^7.21.9",
-            "@babel/types": "^7.21.5"
+            "@babel/code-frame": "^7.24.7",
+            "@babel/parser": "^7.24.7",
+            "@babel/types": "^7.24.7"
           }
         }
       }
     },
     "@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -13227,6 +16775,15 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.7.tgz",
+      "integrity": "sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.24.7"
+      }
+    },
     "@babel/plugin-syntax-import-assertions": {
       "version": "7.20.0",
       "dev": true,
@@ -13239,6 +16796,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+      "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.24.7"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -13381,6 +16947,16 @@
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.7.tgz",
+      "integrity": "sha512-cjRKJ7FobOH2eakx7Ja+KpJRj8+y+/SiB3ooYm/n2UJfxu0oEaOoxOinitkJcPqv9KxS0kxTGPUaR7L2XcXDXA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/plugin-syntax-flow": "^7.24.7"
+      }
+    },
     "@babel/plugin-transform-for-of": {
       "version": "7.18.8",
       "dev": true,
@@ -13481,6 +17057,39 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.7.tgz",
+      "integrity": "sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.24.7"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
+      "integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.24.7",
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/plugin-syntax-jsx": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+          "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.24.7"
+          }
+        }
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -13686,54 +17295,54 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.24.7",
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-function-name": "^7.24.7",
+        "@babel/helper-hoist-variables": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.23.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-          "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+          "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.23.0",
-            "@jridgewell/gen-mapping": "^0.3.2",
-            "@jridgewell/trace-mapping": "^0.3.17",
+            "@babel/types": "^7.24.7",
+            "@jridgewell/gen-mapping": "^0.3.5",
+            "@jridgewell/trace-mapping": "^0.3.25",
             "jsesc": "^2.5.1"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.22.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-          "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+          "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.22.5"
+            "@babel/types": "^7.24.7"
           }
         }
       }
     },
     "@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -13903,6 +17512,1273 @@
       "version": "1.1.3",
       "dev": true
     },
+    "@graphql-codegen/add": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-5.0.2.tgz",
+      "integrity": "sha512-ouBkSvMFUhda5VoKumo/ZvsZM9P5ZTyDsI8LW18VxSNWOjrTeLXBWHG8Gfaai0HwhflPtCYVABbriEcOmrRShQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/cli": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-5.0.2.tgz",
+      "integrity": "sha512-MBIaFqDiLKuO4ojN6xxG9/xL9wmfD3ZjZ7RsPjwQnSHBCUXnEkdKvX+JVpx87Pq29Ycn8wTJUguXnTZ7Di0Mlw==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.18.13",
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.18.13",
+        "@graphql-codegen/client-preset": "^4.2.2",
+        "@graphql-codegen/core": "^4.0.2",
+        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "@graphql-tools/apollo-engine-loader": "^8.0.0",
+        "@graphql-tools/code-file-loader": "^8.0.0",
+        "@graphql-tools/git-loader": "^8.0.0",
+        "@graphql-tools/github-loader": "^8.0.0",
+        "@graphql-tools/graphql-file-loader": "^8.0.0",
+        "@graphql-tools/json-file-loader": "^8.0.0",
+        "@graphql-tools/load": "^8.0.0",
+        "@graphql-tools/prisma-loader": "^8.0.0",
+        "@graphql-tools/url-loader": "^8.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "@whatwg-node/fetch": "^0.8.0",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^8.1.3",
+        "debounce": "^1.2.0",
+        "detect-indent": "^6.0.0",
+        "graphql-config": "^5.0.2",
+        "inquirer": "^8.0.0",
+        "is-glob": "^4.0.1",
+        "jiti": "^1.17.1",
+        "json-to-pretty-yaml": "^1.2.2",
+        "listr2": "^4.0.5",
+        "log-symbols": "^4.0.0",
+        "micromatch": "^4.0.5",
+        "shell-quote": "^1.7.3",
+        "string-env-interpolation": "^1.0.1",
+        "ts-log": "^2.2.3",
+        "tslib": "^2.4.0",
+        "yaml": "^2.3.1",
+        "yargs": "^17.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+          "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^3.3.0",
+            "js-yaml": "^4.1.0",
+            "parse-json": "^5.2.0",
+            "path-type": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "typescript": {
+          "version": "5.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+          "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "yaml": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+          "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/client-preset": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-4.2.6.tgz",
+      "integrity": "sha512-e7SzPb+nxNJfsD0uG+NSyzIeTtCXTouX5VThmcCoqGMDLgF5Lo7932B3HtZCvzmzqcXxRjJ81CmkA2LhlqIbCw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/template": "^7.20.7",
+        "@graphql-codegen/add": "^5.0.2",
+        "@graphql-codegen/gql-tag-operations": "4.0.7",
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/typed-document-node": "^5.0.7",
+        "@graphql-codegen/typescript": "^4.0.7",
+        "@graphql-codegen/typescript-operations": "^4.2.1",
+        "@graphql-codegen/visitor-plugin-common": "^5.2.0",
+        "@graphql-tools/documents": "^1.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "@graphql-typed-document-node/core": "3.2.0",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-IZbpkhwVqgizcjNiaVzNAzm/xbWT6YnGgeOLwVjm4KbJn3V2jchVtuzHH09G5/WkkLSk2wgbXNdwjM41JxO6Eg==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "@graphql-tools/schema": "^10.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/gql-tag-operations": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/gql-tag-operations/-/gql-tag-operations-4.0.7.tgz",
+      "integrity": "sha512-2I69+IDC8pqAohH6cgKse/vPfJ/4TRTJX96PkAKz8S4RD54PUHtBmzCdBInIFEP/vQuH5mFUAaIKXXjznmGOsg==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/visitor-plugin-common": "5.2.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/plugin-helpers": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.0.4.tgz",
+      "integrity": "sha512-MOIuHFNWUnFnqVmiXtrI+4UziMTYrcquljaI5f/T/Bc7oO7sXcfkAvgkNWEEi9xWreYwvuer3VHCuPI/lAFWbw==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^10.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/schema-ast": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-4.0.2.tgz",
+      "integrity": "sha512-5mVAOQQK3Oz7EtMl/l3vOQdc2aYClUzVDHHkMvZlunc+KlGgl81j8TLa+X7ANIllqU4fUEsQU3lJmk4hXP6K7Q==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "@graphql-tools/utils": "^10.0.0",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/typed-document-node": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-5.0.7.tgz",
+      "integrity": "sha512-rgFh96hAbNwPUxLVlRcNhGaw2+y7ZGx7giuETtdO8XzPasTQGWGRkZ3wXQ5UUiTX4X3eLmjnuoXYKT7HoxSznQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/visitor-plugin-common": "5.2.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/typescript": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-4.0.7.tgz",
+      "integrity": "sha512-Gn+JNvQBJhBqH7s83piAJ6UeU/MTj9GXWFO9bdbl8PMLCAM1uFAtg04iHfkGCtDKXcUg5a3Dt/SZG85uk5KuhA==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/schema-ast": "^4.0.2",
+        "@graphql-codegen/visitor-plugin-common": "5.2.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/typescript-apollo-angular": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-apollo-angular/-/typescript-apollo-angular-4.0.0.tgz",
+      "integrity": "sha512-uZQGvZBXJrgJ+9KKeRrKcB8wHCsailJ1WaCizNLf2YsTBUELVX0SQRrSFptAul9qYzsS84LRs6ndJsmSUnER6w==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^3.0.0",
+        "@graphql-codegen/visitor-plugin-common": "2.13.1",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
+          "integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/utils": "^9.0.0",
+            "change-case-all": "1.0.15",
+            "common-tags": "1.8.2",
+            "import-from": "4.0.0",
+            "lodash": "~4.17.0",
+            "tslib": "~2.4.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+              "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+              "dev": true
+            }
+          }
+        },
+        "@graphql-codegen/visitor-plugin-common": {
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.1.tgz",
+          "integrity": "sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==",
+          "dev": true,
+          "requires": {
+            "@graphql-codegen/plugin-helpers": "^2.7.2",
+            "@graphql-tools/optimize": "^1.3.0",
+            "@graphql-tools/relay-operation-optimizer": "^6.5.0",
+            "@graphql-tools/utils": "^8.8.0",
+            "auto-bind": "~4.0.0",
+            "change-case-all": "1.0.14",
+            "dependency-graph": "^0.11.0",
+            "graphql-tag": "^2.11.0",
+            "parse-filepath": "^1.0.2",
+            "tslib": "~2.4.0"
+          },
+          "dependencies": {
+            "@graphql-codegen/plugin-helpers": {
+              "version": "2.7.2",
+              "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz",
+              "integrity": "sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==",
+              "dev": true,
+              "requires": {
+                "@graphql-tools/utils": "^8.8.0",
+                "change-case-all": "1.0.14",
+                "common-tags": "1.8.2",
+                "import-from": "4.0.0",
+                "lodash": "~4.17.0",
+                "tslib": "~2.4.0"
+              }
+            },
+            "@graphql-tools/utils": {
+              "version": "8.13.1",
+              "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
+              "integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+              "dev": true,
+              "requires": {
+                "tslib": "^2.4.0"
+              }
+            },
+            "change-case-all": {
+              "version": "1.0.14",
+              "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.14.tgz",
+              "integrity": "sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==",
+              "dev": true,
+              "requires": {
+                "change-case": "^4.1.2",
+                "is-lower-case": "^2.0.2",
+                "is-upper-case": "^2.0.2",
+                "lower-case": "^2.0.2",
+                "lower-case-first": "^2.0.2",
+                "sponge-case": "^1.0.1",
+                "swap-case": "^2.0.2",
+                "title-case": "^3.0.3",
+                "upper-case": "^2.0.2",
+                "upper-case-first": "^2.0.2"
+              }
+            },
+            "tslib": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+              "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+              "dev": true
+            }
+          }
+        },
+        "@graphql-tools/optimize": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-1.4.0.tgz",
+          "integrity": "sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
+        "@graphql-tools/relay-operation-optimizer": {
+          "version": "6.5.18",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz",
+          "integrity": "sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/relay-compiler": "12.0.0",
+            "@graphql-tools/utils": "^9.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@graphql-tools/utils": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "dev": true,
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/typescript-operations": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-4.2.1.tgz",
+      "integrity": "sha512-LhEPsaP+AI65zfK2j6CBAL4RT0bJL/rR9oRWlvwtHLX0t7YQr4CP4BXgvvej9brYdedAxHGPWeV1tPHy5/z9KQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/typescript": "^4.0.7",
+        "@graphql-codegen/visitor-plugin-common": "5.2.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/visitor-plugin-common": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.2.0.tgz",
+      "integrity": "sha512-0p8AwmARaZCAlDFfQu6Sz+JV6SjbPDx3y2nNM7WAAf0au7Im/GpJ7Ke3xaIYBc1b2rTZ+DqSTJI/zomENGD9NA==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/apollo-engine-loader": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.1.tgz",
+      "integrity": "sha512-NaPeVjtrfbPXcl+MLQCJLWtqe2/E4bbAqcauEOQ+3sizw1Fc2CNmhHRF8a6W4D0ekvTRRXAMptXYgA2uConbrA==",
+      "dev": true,
+      "requires": {
+        "@ardatan/sync-fetch": "^0.0.1",
+        "@graphql-tools/utils": "^10.0.13",
+        "@whatwg-node/fetch": "^0.9.0",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@whatwg-node/events": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+          "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+          "dev": true
+        },
+        "@whatwg-node/fetch": {
+          "version": "0.9.18",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+          "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+          "dev": true,
+          "requires": {
+            "@whatwg-node/node-fetch": "^0.5.7",
+            "urlpattern-polyfill": "^10.0.0"
+          }
+        },
+        "@whatwg-node/node-fetch": {
+          "version": "0.5.11",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+          "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+          "dev": true,
+          "requires": {
+            "@kamilkisiela/fast-url-parser": "^1.1.4",
+            "@whatwg-node/events": "^0.1.0",
+            "busboy": "^1.6.0",
+            "fast-querystring": "^1.1.1",
+            "tslib": "^2.3.1"
+          }
+        },
+        "urlpattern-polyfill": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+          "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/batch-execute": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.4.tgz",
+      "integrity": "sha512-kkebDLXgDrep5Y0gK1RN3DMUlLqNhg60OAz0lTCqrYeja6DshxLtLkj+zV4mVbBA4mQOEoBmw6g1LZs3dA84/w==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^10.0.13",
+        "dataloader": "^2.2.2",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      }
+    },
+    "@graphql-tools/code-file-loader": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.2.tgz",
+      "integrity": "sha512-GrLzwl1QV2PT4X4TEEfuTmZYzIZHLqoTGBjczdUzSqgCCcqwWzLB3qrJxFQfI8e5s1qZ1bhpsO9NoMn7tvpmyA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/graphql-tag-pluck": "8.3.1",
+        "@graphql-tools/utils": "^10.0.13",
+        "globby": "^11.0.3",
+        "tslib": "^2.4.0",
+        "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/delegate": {
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.11.tgz",
+      "integrity": "sha512-+sKeecdIVXhFB/66e5yjeKYZ3Lpn52yNG637ElVhciuLGgFc153rC6l6zcuNd9yx5wMrNx35U/h3HsMIEI3xNw==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/batch-execute": "^9.0.4",
+        "@graphql-tools/executor": "^1.2.1",
+        "@graphql-tools/schema": "^10.0.4",
+        "@graphql-tools/utils": "^10.2.1",
+        "dataloader": "^2.2.2",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@graphql-tools/documents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/documents/-/documents-1.0.1.tgz",
+      "integrity": "sha512-aweoMH15wNJ8g7b2r4C4WRuJxZ0ca8HtNO54rkye/3duxTkW4fGBEutCx03jCIr5+a1l+4vFJNP859QnAVBVCA==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@graphql-tools/executor": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.6.tgz",
+      "integrity": "sha512-+1kjfqzM5T2R+dCw7F4vdJ3CqG+fY/LYJyhNiWEFtq0ToLwYzR/KKyD8YuzTirEjSxWTVlcBh7endkx5n5F6ew==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^10.1.1",
+        "@graphql-typed-document-node/core": "3.2.0",
+        "@repeaterjs/repeater": "^3.0.4",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      }
+    },
+    "@graphql-tools/executor-graphql-ws": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.1.2.tgz",
+      "integrity": "sha512-+9ZK0rychTH1LUv4iZqJ4ESbmULJMTsv3XlFooPUngpxZkk00q6LqHKJRrsLErmQrVaC7cwQCaRBJa0teK17Lg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^10.0.13",
+        "@types/ws": "^8.0.0",
+        "graphql-ws": "^5.14.0",
+        "isomorphic-ws": "^5.0.0",
+        "tslib": "^2.4.0",
+        "ws": "^8.13.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.17.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+          "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "@graphql-tools/executor-http": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.9.tgz",
+      "integrity": "sha512-+NXaZd2MWbbrWHqU4EhXcrDbogeiCDmEbrAN+rMn4Nu2okDjn2MTFDbTIab87oEubQCH4Te1wDkWPKrzXup7+Q==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^10.0.13",
+        "@repeaterjs/repeater": "^3.0.4",
+        "@whatwg-node/fetch": "^0.9.0",
+        "extract-files": "^11.0.0",
+        "meros": "^1.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "20.14.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+          "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
+        "@whatwg-node/events": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+          "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+          "dev": true
+        },
+        "@whatwg-node/fetch": {
+          "version": "0.9.18",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+          "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+          "dev": true,
+          "requires": {
+            "@whatwg-node/node-fetch": "^0.5.7",
+            "urlpattern-polyfill": "^10.0.0"
+          }
+        },
+        "@whatwg-node/node-fetch": {
+          "version": "0.5.11",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+          "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+          "dev": true,
+          "requires": {
+            "@kamilkisiela/fast-url-parser": "^1.1.4",
+            "@whatwg-node/events": "^0.1.0",
+            "busboy": "^1.6.0",
+            "fast-querystring": "^1.1.1",
+            "tslib": "^2.3.1"
+          }
+        },
+        "meros": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
+          "integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
+          "dev": true,
+          "requires": {}
+        },
+        "urlpattern-polyfill": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+          "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/executor-legacy-ws": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.6.tgz",
+      "integrity": "sha512-lDSxz9VyyquOrvSuCCnld3256Hmd+QI2lkmkEv7d4mdzkxkK4ddAWW1geQiWrQvWmdsmcnGGlZ7gDGbhEExwqg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^10.0.13",
+        "@types/ws": "^8.0.0",
+        "isomorphic-ws": "^5.0.0",
+        "tslib": "^2.4.0",
+        "ws": "^8.15.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.17.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+          "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "@graphql-tools/git-loader": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.6.tgz",
+      "integrity": "sha512-FQFO4H5wHAmHVyuUQrjvPE8re3qJXt50TWHuzrK3dEaief7JosmlnkLMDMbMBwtwITz9u1Wpl6doPhT2GwKtlw==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/graphql-tag-pluck": "8.3.1",
+        "@graphql-tools/utils": "^10.0.13",
+        "is-glob": "4.0.3",
+        "micromatch": "^4.0.4",
+        "tslib": "^2.4.0",
+        "unixify": "^1.0.0"
+      }
+    },
+    "@graphql-tools/github-loader": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-8.0.1.tgz",
+      "integrity": "sha512-W4dFLQJ5GtKGltvh/u1apWRFKBQOsDzFxO9cJkOYZj1VzHCpRF43uLST4VbCfWve+AwBqOuKr7YgkHoxpRMkcg==",
+      "dev": true,
+      "requires": {
+        "@ardatan/sync-fetch": "^0.0.1",
+        "@graphql-tools/executor-http": "^1.0.9",
+        "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+        "@graphql-tools/utils": "^10.0.13",
+        "@whatwg-node/fetch": "^0.9.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "dependencies": {
+        "@whatwg-node/events": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+          "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+          "dev": true
+        },
+        "@whatwg-node/fetch": {
+          "version": "0.9.18",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+          "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+          "dev": true,
+          "requires": {
+            "@whatwg-node/node-fetch": "^0.5.7",
+            "urlpattern-polyfill": "^10.0.0"
+          }
+        },
+        "@whatwg-node/node-fetch": {
+          "version": "0.5.11",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+          "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+          "dev": true,
+          "requires": {
+            "@kamilkisiela/fast-url-parser": "^1.1.4",
+            "@whatwg-node/events": "^0.1.0",
+            "busboy": "^1.6.0",
+            "fast-querystring": "^1.1.1",
+            "tslib": "^2.3.1"
+          }
+        },
+        "urlpattern-polyfill": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+          "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/graphql-file-loader": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.1.tgz",
+      "integrity": "sha512-7gswMqWBabTSmqbaNyWSmRRpStWlcCkBc73E6NZNlh4YNuiyKOwbvSkOUYFOqFMfEL+cFsXgAvr87Vz4XrYSbA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/import": "7.0.1",
+        "@graphql-tools/utils": "^10.0.13",
+        "globby": "^11.0.3",
+        "tslib": "^2.4.0",
+        "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/graphql-tag-pluck": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.1.tgz",
+      "integrity": "sha512-ujits9tMqtWQQq4FI4+qnVPpJvSEn7ogKtyN/gfNT+ErIn6z1e4gyVGQpTK5sgAUXq1lW4gU/5fkFFC5/sL2rQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.22.9",
+        "@babel/parser": "^7.16.8",
+        "@babel/plugin-syntax-import-assertions": "^7.20.0",
+        "@babel/traverse": "^7.16.8",
+        "@babel/types": "^7.16.8",
+        "@graphql-tools/utils": "^10.0.13",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+          "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+          "dev": true,
+          "requires": {
+            "@ampproject/remapping": "^2.2.0",
+            "@babel/code-frame": "^7.24.7",
+            "@babel/generator": "^7.24.7",
+            "@babel/helper-compilation-targets": "^7.24.7",
+            "@babel/helper-module-transforms": "^7.24.7",
+            "@babel/helpers": "^7.24.7",
+            "@babel/parser": "^7.24.7",
+            "@babel/template": "^7.24.7",
+            "@babel/traverse": "^7.24.7",
+            "@babel/types": "^7.24.7",
+            "convert-source-map": "^2.0.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.2",
+            "json5": "^2.2.3",
+            "semver": "^6.3.1"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+          "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.24.7",
+            "@jridgewell/gen-mapping": "^0.3.5",
+            "@jridgewell/trace-mapping": "^0.3.25",
+            "jsesc": "^2.5.1"
+          }
+        },
+        "@babel/template": {
+          "version": "7.24.7",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+          "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.24.7",
+            "@babel/parser": "^7.24.7",
+            "@babel/types": "^7.24.7"
+          }
+        },
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/import": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.1.tgz",
+      "integrity": "sha512-935uAjAS8UAeXThqHfYVr4HEAp6nHJ2sximZKO1RzUTq5WoALMAhhGARl0+ecm6X+cqNUwIChJbjtaa6P/ML0w==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^10.0.13",
+        "resolve-from": "5.0.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@graphql-tools/json-file-loader": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.1.tgz",
+      "integrity": "sha512-lAy2VqxDAHjVyqeJonCP6TUemrpYdDuKt25a10X6zY2Yn3iFYGnuIDQ64cv3ytyGY6KPyPB+Kp+ZfOkNDG3FQA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^10.0.13",
+        "globby": "^11.0.3",
+        "tslib": "^2.4.0",
+        "unixify": "^1.0.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/load": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.2.tgz",
+      "integrity": "sha512-S+E/cmyVmJ3CuCNfDuNF2EyovTwdWfQScXv/2gmvJOti2rGD8jTt9GYVzXaxhblLivQR9sBUCNZu/w7j7aXUCA==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/schema": "^10.0.3",
+        "@graphql-tools/utils": "^10.0.13",
+        "p-limit": "3.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@graphql-tools/merge": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.4.tgz",
+      "integrity": "sha512-MivbDLUQ+4Q8G/Hp/9V72hbn810IJDEZQ57F01sHnlrrijyadibfVhaQfW/pNH+9T/l8ySZpaR/DpL5i+ruZ+g==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/utils": "^10.0.13",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@graphql-tools/optimize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/optimize/-/optimize-2.0.0.tgz",
+      "integrity": "sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@graphql-tools/prisma-loader": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.4.tgz",
+      "integrity": "sha512-hqKPlw8bOu/GRqtYr0+dINAI13HinTVYBDqhwGAPIFmLr5s+qKskzgCiwbsckdrb5LWVFmVZc+UXn80OGiyBzg==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/url-loader": "^8.0.2",
+        "@graphql-tools/utils": "^10.0.13",
+        "@types/js-yaml": "^4.0.0",
+        "@whatwg-node/fetch": "^0.9.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.1",
+        "dotenv": "^16.0.0",
+        "graphql-request": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "jose": "^5.0.0",
+        "js-yaml": "^4.0.0",
+        "lodash": "^4.17.20",
+        "scuid": "^1.1.0",
+        "tslib": "^2.4.0",
+        "yaml-ast-parser": "^0.0.43"
+      },
+      "dependencies": {
+        "@whatwg-node/events": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+          "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+          "dev": true
+        },
+        "@whatwg-node/fetch": {
+          "version": "0.9.18",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+          "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+          "dev": true,
+          "requires": {
+            "@whatwg-node/node-fetch": "^0.5.7",
+            "urlpattern-polyfill": "^10.0.0"
+          }
+        },
+        "@whatwg-node/node-fetch": {
+          "version": "0.5.11",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+          "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+          "dev": true,
+          "requires": {
+            "@kamilkisiela/fast-url-parser": "^1.1.4",
+            "@whatwg-node/events": "^0.1.0",
+            "busboy": "^1.6.0",
+            "fast-querystring": "^1.1.1",
+            "tslib": "^2.3.1"
+          }
+        },
+        "agent-base": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+          "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "http-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+          "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "urlpattern-polyfill": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+          "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-tools/relay-operation-optimizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.1.tgz",
+      "integrity": "sha512-y0ZrQ/iyqWZlsS/xrJfSir3TbVYJTYmMOu4TaSz6F4FRDTQ3ie43BlKkhf04rC28pnUOS4BO9pDcAo1D30l5+A==",
+      "dev": true,
+      "requires": {
+        "@ardatan/relay-compiler": "12.0.0",
+        "@graphql-tools/utils": "^10.0.13",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@graphql-tools/schema": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.4.tgz",
+      "integrity": "sha512-HuIwqbKxPaJujox25Ra4qwz0uQzlpsaBOzO6CVfzB/MemZdd+Gib8AIvfhQArK0YIN40aDran/yi+E5Xf0mQww==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/merge": "^9.0.3",
+        "@graphql-tools/utils": "^10.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      }
+    },
+    "@graphql-tools/url-loader": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.2.tgz",
+      "integrity": "sha512-1dKp2K8UuFn7DFo1qX5c1cyazQv2h2ICwA9esHblEqCYrgf69Nk8N7SODmsfWg94OEaI74IqMoM12t7eIGwFzQ==",
+      "dev": true,
+      "requires": {
+        "@ardatan/sync-fetch": "^0.0.1",
+        "@graphql-tools/delegate": "^10.0.4",
+        "@graphql-tools/executor-graphql-ws": "^1.1.2",
+        "@graphql-tools/executor-http": "^1.0.9",
+        "@graphql-tools/executor-legacy-ws": "^1.0.6",
+        "@graphql-tools/utils": "^10.0.13",
+        "@graphql-tools/wrap": "^10.0.2",
+        "@types/ws": "^8.0.0",
+        "@whatwg-node/fetch": "^0.9.0",
+        "isomorphic-ws": "^5.0.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.11",
+        "ws": "^8.12.0"
+      },
+      "dependencies": {
+        "@whatwg-node/events": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+          "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+          "dev": true
+        },
+        "@whatwg-node/fetch": {
+          "version": "0.9.18",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+          "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
+          "dev": true,
+          "requires": {
+            "@whatwg-node/node-fetch": "^0.5.7",
+            "urlpattern-polyfill": "^10.0.0"
+          }
+        },
+        "@whatwg-node/node-fetch": {
+          "version": "0.5.11",
+          "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+          "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+          "dev": true,
+          "requires": {
+            "@kamilkisiela/fast-url-parser": "^1.1.4",
+            "@whatwg-node/events": "^0.1.0",
+            "busboy": "^1.6.0",
+            "fast-querystring": "^1.1.1",
+            "tslib": "^2.3.1"
+          }
+        },
+        "urlpattern-polyfill": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+          "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+          "dev": true
+        },
+        "ws": {
+          "version": "8.17.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+          "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.2.1.tgz",
+      "integrity": "sha512-U8OMdkkEt3Vp3uYHU2pMc6mwId7axVAcSSmcqJcUmWNPqY2pfee5O655ybTI2kNPWAe58Zu6gLu4Oi4QT4BgWA==",
+      "dev": true,
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-inspect": "1.0.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@graphql-tools/wrap": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.5.tgz",
+      "integrity": "sha512-Cbr5aYjr3HkwdPvetZp1cpDWTGdD1Owgsb3z/ClzhmrboiK86EnQDxDvOJiQkDCPWE9lNBwj8Y4HfxroY0D9DQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/delegate": "^10.0.4",
+        "@graphql-tools/schema": "^10.0.3",
+        "@graphql-tools/utils": "^10.1.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      }
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
+      "requires": {}
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "dev": true,
@@ -13919,16 +18795,20 @@
       "dev": true
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.2",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
       "requires": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "@jridgewell/set-array": {
-      "version": "1.1.2",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true
     },
     "@jridgewell/source-map": {
@@ -13944,13 +18824,13 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       },
       "dependencies": {
         "@jridgewell/resolve-uri": {
@@ -13958,6 +18838,12 @@
           "dev": true
         }
       }
+    },
+    "@kamilkisiela/fast-url-parser": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz",
+      "integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
+      "dev": true
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -14086,6 +18972,61 @@
           }
         }
       }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
+      "dev": true,
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
+      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
+      "dev": true,
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@repeaterjs/repeater": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
+      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+      "dev": true
     },
     "@schematics/angular": {
       "version": "15.0.4",
@@ -14233,6 +19174,12 @@
       "requires": {
         "@types/jasmine": "*"
       }
+    },
+    "@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.11",
@@ -14469,6 +19416,38 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@whatwg-node/events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.0.3.tgz",
+      "integrity": "sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==",
+      "dev": true
+    },
+    "@whatwg-node/fetch": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.8.8.tgz",
+      "integrity": "sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==",
+      "dev": true,
+      "requires": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "@whatwg-node/node-fetch": "^0.3.6",
+        "busboy": "^1.6.0",
+        "urlpattern-polyfill": "^8.0.0",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "@whatwg-node/node-fetch": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz",
+      "integrity": "sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==",
+      "dev": true,
+      "requires": {
+        "@whatwg-node/events": "^0.0.3",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "fast-url-parser": "^1.1.3",
+        "tslib": "^2.3.1"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "dev": true
@@ -14666,6 +19645,12 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true
     },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
     "array-uniq": {
       "version": "1.0.3",
       "dev": true
@@ -14674,11 +19659,28 @@
       "version": "1.0.1",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.6",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
+      }
+    },
+    "asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dev": true,
+      "requires": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
       }
     },
     "assert-plus": {
@@ -14689,8 +19691,20 @@
       "version": "0.0.7",
       "dev": true
     },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
+      "dev": true
+    },
+    "auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
       "dev": true
     },
     "autoprefixer": {
@@ -14769,6 +19783,47 @@
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.3"
+      }
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
+      "dev": true
+    },
+    "babel-preset-fbjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+      "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-class-properties": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-property-literals": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
       }
     },
     "balanced-match": {
@@ -14927,6 +19982,15 @@
         }
       }
     },
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
     "buffer": {
       "version": "5.7.1",
       "dev": true,
@@ -14948,6 +20012,15 @@
       "dev": true,
       "requires": {
         "semver": "^7.0.0"
+      }
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "requires": {
+        "streamsearch": "^1.1.0"
       }
     },
     "bytes": {
@@ -15045,15 +20118,36 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "requires": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "camelcase": {
       "version": "5.3.1",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001494",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz",
-      "integrity": "sha512-sY2B5Qyl46ZzfYDegrl8GBCzdawSLT4ThM9b9F+aDYUrAG2zCOyMbd2Tq34mS1g4ZKBfjRlzOohQMxx28x6wJg==",
+      "version": "1.0.30001629",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz",
+      "integrity": "sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==",
       "dev": true
+    },
+    "capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -15066,6 +20160,44 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "requires": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "change-case-all": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
+      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
+      "dev": true,
+      "requires": {
+        "change-case": "^4.1.2",
+        "is-lower-case": "^2.0.2",
+        "is-upper-case": "^2.0.2",
+        "lower-case": "^2.0.2",
+        "lower-case-first": "^2.0.2",
+        "sponge-case": "^1.0.1",
+        "swap-case": "^2.0.2",
+        "title-case": "^3.0.3",
+        "upper-case": "^2.0.2",
+        "upper-case-first": "^2.0.2"
       }
     },
     "chardet": {
@@ -15108,6 +20240,16 @@
     "cli-spinners": {
       "version": "2.7.0",
       "dev": true
+    },
+    "cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      }
     },
     "cli-width": {
       "version": "3.0.0",
@@ -15215,6 +20357,12 @@
       "version": "2.20.3",
       "dev": true
     },
+    "common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -15304,6 +20452,17 @@
     "console-control-strings": {
       "version": "1.1.0",
       "dev": true
+    },
+    "constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -15463,6 +20622,24 @@
         }
       }
     },
+    "cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "cross-inspect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.0.tgz",
+      "integrity": "sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -15548,8 +20725,20 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
+      "dev": true
+    },
     "date-format": {
       "version": "4.0.13",
+      "dev": true
+    },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
       "dev": true
     },
     "debug": {
@@ -15644,6 +20833,12 @@
       "version": "1.2.0",
       "dev": true
     },
+    "detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true
+    },
     "detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -15713,6 +20908,28 @@
         "domhandler": "^4.2.0"
       }
     },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true
+    },
+    "dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "dev": true,
@@ -15726,7 +20943,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.284",
+      "version": "1.4.796",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.796.tgz",
+      "integrity": "sha512-NglN/xprcM+SHD2XCli4oC6bWe6kHoytcyLKCWXmRL854F0qhPhaYgUswUsglnPxYaNQIg2uMY4BvaomIf3kLA==",
       "dev": true
     },
     "emitter-component": {
@@ -15880,7 +21099,9 @@
       "dev": true
     },
     "escalade": {
-      "version": "3.1.1",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true
     },
     "escape-html": {
@@ -16065,8 +21286,20 @@
         "tmp": "^0.0.33"
       }
     },
+    "extract-files": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "dev": true
+    },
     "extsprintf": {
       "version": "1.3.0",
+      "dev": true
+    },
+    "fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -16088,6 +21321,32 @@
       "version": "2.1.0",
       "dev": true
     },
+    "fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dev": true,
+      "requires": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+          "dev": true
+        }
+      }
+    },
     "fastparse": {
       "version": "1.1.2",
       "dev": true
@@ -16107,6 +21366,44 @@
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
+    },
+    "fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "requires": {
+        "bser": "2.1.1"
+      }
+    },
+    "fbjs": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.1.5",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^1.0.35"
+      },
+      "dependencies": {
+        "ua-parser-js": {
+          "version": "1.0.38",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz",
+          "integrity": "sha512-Aq5ppTOfvrCMgAPneW1HfWj66Xi7XL+/mIy996R1/CLS/rcyJQm6QZdsKrUeivDFQ+Oc9Wyuwor8Ze8peEoUoQ==",
+          "dev": true
+        }
+      }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
     },
     "figures": {
       "version": "3.2.0",
@@ -16336,6 +21633,104 @@
       "version": "4.2.10",
       "dev": true
     },
+    "graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "dev": true,
+      "peer": true
+    },
+    "graphql-config": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.3.tgz",
+      "integrity": "sha512-BNGZaoxIBkv9yy6Y7omvsaBUHOzfFcII3UN++tpH8MGOKFPFkCPZuwx09ggANMt8FgyWP1Od8SWPmrUEZca4NQ==",
+      "dev": true,
+      "requires": {
+        "@graphql-tools/graphql-file-loader": "^8.0.0",
+        "@graphql-tools/json-file-loader": "^8.0.0",
+        "@graphql-tools/load": "^8.0.0",
+        "@graphql-tools/merge": "^9.0.0",
+        "@graphql-tools/url-loader": "^8.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "cosmiconfig": "^8.1.0",
+        "jiti": "^1.18.2",
+        "minimatch": "^4.2.3",
+        "string-env-interpolation": "^1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+          "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^3.3.0",
+            "js-yaml": "^4.1.0",
+            "parse-json": "^5.2.0",
+            "path-type": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
+          "integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "typescript": {
+          "version": "5.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+          "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
+      }
+    },
+    "graphql-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "dev": true,
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "graphql-ws": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.0.tgz",
+      "integrity": "sha512-Ju2RCU2dQMgSKtArPbEtsK5gNLnsQyTNIo/T7cZNp96niC1x0KdJNZV0TIoilceBPQwfb5itrGl8pkFeOUMl4A==",
+      "dev": true,
+      "requires": {}
+    },
     "hammerjs": {
       "version": "2.0.8"
     },
@@ -16417,6 +21812,16 @@
     "hdr-histogram-percentiles-obj": {
       "version": "3.0.0",
       "dev": true
+    },
+    "header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dev": true,
+      "requires": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -16656,6 +22061,12 @@
         }
       }
     },
+    "import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "dev": true
@@ -16751,6 +22162,15 @@
         }
       }
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "ip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
@@ -16762,6 +22182,16 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
       "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
       "dev": true
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -16810,6 +22240,15 @@
       "version": "1.0.1",
       "dev": true
     },
+    "is-lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
+      "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "is-number": {
       "version": "7.0.0",
       "dev": true
@@ -16845,6 +22284,15 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -16855,12 +22303,36 @@
       "version": "1.0.0",
       "dev": true
     },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
+    },
     "is-unicode-supported": {
       "version": "0.1.0",
       "dev": true
     },
+    "is-upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
+      "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "is-what": {
       "version": "3.14.1",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "is-wsl": {
@@ -16885,6 +22357,13 @@
     "isobject": {
       "version": "3.0.1",
       "dev": true
+    },
+    "isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "dev": true,
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",
@@ -17037,6 +22516,18 @@
         }
       }
     },
+    "jiti": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.3.tgz",
+      "integrity": "sha512-uy2bNX5zQ+tESe+TiC7ilGRz8AtRGmnJH55NC5S0nSUjvvvM2hJHmefHErugGXN4pNv4Qx7vLsnNw9qJ9mtIsw==",
+      "dev": true
+    },
+    "jose": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.4.0.tgz",
+      "integrity": "sha512-6rpxTHPAQyWMb9A35BroFl1Sp0ST3DpPcm5EVIxZxdH+e0Hv9fwhyB3XLKFUcHNpdSDnETmBfuPPTTlYz5+USw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17074,6 +22565,16 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "dev": true
+    },
+    "json-to-pretty-yaml": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
+      "integrity": "sha512-rvm6hunfCcqegwYaG5T4yKJWxc9FXFgBVrcTZ4XfSVRwa5HA/Xs+vB/Eo9treYYHCeNM0nrSUr82V/M31Urc7A==",
+      "dev": true,
+      "requires": {
+        "remedial": "^1.0.7",
+        "remove-trailing-spaces": "^1.0.6"
+      }
     },
     "json5": {
       "version": "2.2.3",
@@ -17332,6 +22833,33 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "listr2": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "dev": true,
+      "requires": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.5",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
+      }
+    },
     "loader-runner": {
       "version": "4.3.0",
       "dev": true
@@ -17353,6 +22881,12 @@
     },
     "lodash.debounce": {
       "version": "4.0.8",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
     "log-symbols": {
@@ -17402,6 +22936,66 @@
         }
       }
     },
+    "log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "log4js": {
       "version": "6.6.1",
       "dev": true,
@@ -17411,6 +23005,33 @@
         "flatted": "^3.2.6",
         "rfdc": "^1.3.0",
         "streamroller": "^3.1.2"
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "lower-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-2.0.2.tgz",
+      "integrity": "sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
       }
     },
     "lru-cache": {
@@ -17549,6 +23170,12 @@
           }
         }
       }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -17773,10 +23400,29 @@
         "node-gyp-build": "^4.2.2"
       }
     },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node-addon-api": {
       "version": "3.2.1",
       "dev": true,
       "optional": true
+    },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-forge": {
       "version": "1.3.1",
@@ -17814,10 +23460,16 @@
       "dev": true,
       "optional": true
     },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true
+    },
     "node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "nopt": {
@@ -18049,6 +23701,12 @@
         "boolbase": "^1.0.0"
       }
     },
+    "nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "dev": true
@@ -18161,6 +23819,15 @@
       "version": "1.0.2",
       "dev": true
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
     "p-locate": {
       "version": "4.1.0",
       "dev": true,
@@ -18267,6 +23934,16 @@
       "version": "1.0.11",
       "dev": true
     },
+    "param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -18274,6 +23951,17 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
       }
     },
     "parse-json": {
@@ -18365,6 +24053,26 @@
       "version": "1.3.3",
       "dev": true
     },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dev": true,
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "dev": true
@@ -18387,6 +24095,21 @@
       "version": "1.0.7",
       "dev": true
     },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -18402,7 +24125,9 @@
       "dev": true
     },
     "picocolors": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "dev": true
     },
     "picomatch": {
@@ -18516,6 +24241,15 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -18721,6 +24455,29 @@
       "version": "2.1.1",
       "dev": true
     },
+    "pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
+      }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "dev": true
+    },
     "q": {
       "version": "1.4.1",
       "dev": true
@@ -18892,6 +24649,35 @@
           "dev": true
         }
       }
+    },
+    "relay-runtime": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
+      "integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "fbjs": "^3.0.0",
+        "invariant": "^2.2.4"
+      }
+    },
+    "remedial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true
+    },
+    "remove-trailing-spaces": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz",
+      "integrity": "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==",
+      "dev": true
     },
     "request": {
       "version": "2.88.2",
@@ -19105,6 +24891,12 @@
         "ajv-keywords": "^5.0.0"
       }
     },
+    "scuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/scuid/-/scuid-1.1.0.tgz",
+      "integrity": "sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==",
+      "dev": true
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -19225,6 +25017,17 @@
         }
       }
     },
+    "sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "serialize-javascript": {
       "version": "6.0.0",
       "dev": true,
@@ -19340,6 +25143,12 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shell-quote": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "dev": true
+    },
     "side-channel": {
       "version": "1.0.4",
       "dev": true,
@@ -19353,13 +25162,66 @@
       "version": "3.0.7",
       "dev": true
     },
+    "signedsource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+      "integrity": "sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==",
+      "dev": true
+    },
     "slash": {
       "version": "4.0.0",
       "dev": true
     },
+    "slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
     "smart-buffer": {
       "version": "4.2.0",
       "dev": true
+    },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dev": true,
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
     },
     "socket.io": {
       "version": "4.6.2",
@@ -19517,6 +25379,15 @@
         "wbuf": "^1.7.3"
       }
     },
+    "sponge-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-1.0.1.tgz",
+      "integrity": "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "sprintf-js": {
       "version": "1.1.2",
       "dev": true
@@ -19565,6 +25436,12 @@
         "fs-extra": "^8.1.0"
       }
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true
+    },
     "string_decoder": {
       "version": "1.3.0",
       "dev": true,
@@ -19577,6 +25454,12 @@
           "dev": true
         }
       }
+    },
+    "string-env-interpolation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+      "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
+      "dev": true
     },
     "string-width": {
       "version": "4.2.3",
@@ -19618,6 +25501,15 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "dev": true
+    },
+    "swap-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-2.0.2.tgz",
+      "integrity": "sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      }
     },
     "symbol-observable": {
       "version": "4.0.0",
@@ -19724,6 +25616,15 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "dev": true,
@@ -19754,8 +25655,20 @@
         "punycode": "^2.1.1"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "tree-kill": {
       "version": "1.2.2",
+      "dev": true
+    },
+    "ts-log": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.5.tgz",
+      "integrity": "sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==",
       "dev": true
     },
     "ts-node": {
@@ -19883,6 +25796,8 @@
     },
     "typescript": {
       "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "ua-parser-js": {
@@ -19890,6 +25805,20 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
       "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
       "dev": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -19929,16 +25858,56 @@
       "version": "0.1.2",
       "dev": true
     },
+    "unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.10",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
       "dev": true,
       "requires": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
+      }
+    },
+    "upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
       }
     },
     "uri-js": {
@@ -19947,6 +25916,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -19983,6 +25958,12 @@
       "requires": {
         "builtins": "^5.0.0"
       }
+    },
+    "value-or-promise": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",
@@ -20035,6 +26016,33 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true
+    },
+    "webcrypto-core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.0.tgz",
+      "integrity": "sha512-kR1UQNH8MD42CYuLzvibfakG5Ew5seG85dMMoAM/1LqvckxaF6pUiidLuraIu4V+YCIFabYecUZAW0TuxAoaqw==",
+      "dev": true,
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+          "dev": true
+        }
       }
     },
     "webdriver-js-extender": {
@@ -20110,6 +26118,12 @@
           "dev": true
         }
       }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "webpack": {
       "version": "5.76.1",
@@ -20274,6 +26288,16 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "which": {
       "version": "1.3.1",
       "dev": true,
@@ -20362,6 +26386,12 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
+    "yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true
+    },
     "yargs": {
       "version": "17.6.2",
       "dev": true,
@@ -20392,6 +26422,12 @@
     },
     "yn": {
       "version": "2.0.0",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     },
     "zone.js": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "gh-build": "ng build --configuration production --base-href=/lu-explorer/",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "codegen": "graphql-codegen --config codegen.ts"
   },
   "private": true,
   "dependencies": {
@@ -21,10 +22,10 @@
     "@angular/platform-browser": "15.0.4",
     "@angular/platform-browser-dynamic": "15.0.4",
     "@angular/router": "15.0.4",
+    "@types/leaflet": "^1.7.1",
     "core-js": "^2.6.12",
     "flexsearch": "^0.7.21",
     "leaflet": "^1.7.1",
-    "@types/leaflet": "^1.7.1",
     "rxjs": "^6.6.7",
     "tslib": "^2.2.0",
     "typeface-nunito": "0.0.72",
@@ -37,6 +38,8 @@
     "@angular/cli": "15.0.4",
     "@angular/compiler-cli": "15.0.4",
     "@angular/language-service": "15.0.4",
+    "@graphql-codegen/cli": "5.0.2",
+    "@graphql-codegen/typescript-apollo-angular": "4.0.0",
     "@types/jasmine": "^3.6.9",
     "@types/jasminewd2": "^2.0.8",
     "@types/node": "^12.20.7",
@@ -51,6 +54,6 @@
     "protractor": "~7.0.0",
     "ts-node": "~4.1.0",
     "tslint": "~6.1.0",
-    "typescript": "4.8.4"
+    "typescript": "^4.8.4"
   }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,0 +1,2309 @@
+schema {
+	query: Query
+}
+
+type AccessoryDefaultLoc {
+	GroupID: Int
+	Description: String
+	Pos_X: Float
+	Pos_Y: Float
+	Pos_Z: Float
+	Rot_X: Float
+	Rot_Y: Float
+	Rot_Z: Float
+}
+
+type ActivityRewards {
+	objectTemplate: Objects
+	ActivityRewardIndex: Int
+	activityRating: Int
+	LootMatrixIndex: LootMatrix
+	CurrencyIndex: Int
+	ChallengeRating: Int
+	description: String
+}
+
+type MissionEmail {
+	ID: Int
+	messageType: Int
+	notificationGroup: Int
+	missionID: Missions
+	attachmentLOT: Objects
+	localize: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	announceText_loc: String
+	announceText_en_US: String
+	announceText_de_DE: String
+	announceText_en_GB: String
+	bodyText_loc: String
+	bodyText_en_US: String
+	bodyText_de_DE: String
+	bodyText_en_GB: String
+	senderName_loc: String
+	senderName_en_US: String
+	senderName_de_DE: String
+	senderName_en_GB: String
+	subjectText_loc: String
+	subjectText_en_US: String
+	subjectText_de_DE: String
+	subjectText_en_GB: String
+}
+
+type MissionPrereqs {
+	mission: Missions!
+	andGroup: Int!
+	prereqMission: Missions!
+	prereqMissionState: Int
+}
+
+type BrickColors {
+	id: Int
+	red: Float
+	green: Float
+	blue: Float
+	alpha: Float
+	legopaletteid: Int
+	description: String
+	validTypes: Int
+	validCharacters: Int
+	factoryValid: Int
+}
+
+type WhatsCoolItemSpotlight {
+	id: Int
+	itemID: Objects
+	localize: Int
+	gate_version: FeatureGating
+	locStatus: Int
+	description_loc: String
+	description_en_US: String
+	description_de_DE: String
+	description_en_GB: String
+}
+
+type TextLanguage {
+	TextID: Int
+	LanguageID: Int
+	Text: String
+}
+
+type MissionNPCComponent {
+	id: Int
+	missionID: Missions
+	offersMission: Int
+	acceptsMission: Int
+	gate_version: FeatureGating
+}
+
+type LUPExhibitModelData {
+	LOT: Objects
+	minXZ: Float
+	maxXZ: Float
+	maxY: Float
+	description: String
+	owner: String
+}
+
+type BehaviorParameter {
+	behaviorID: Int
+	parameterID: String
+	value: Float
+}
+
+type Emotes {
+	id: Int
+	animationName: String
+	iconFilename: String
+	channel: String
+	command: String
+	locked: Int
+	localize: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	outputText_loc: String
+	outputText_en_US: String
+	outputText_de_DE: String
+	outputText_en_GB: String
+	Missions_reward_emote: [Missions!]!
+	Missions_reward_emote2: [Missions!]!
+	Missions_reward_emote3: [Missions!]!
+	Missions_reward_emote4: [Missions!]!
+	SpeedchatMenu: [SpeedchatMenu!]!
+	SpeedchatMenu_emoteId: [SpeedchatMenu!]!
+}
+
+type LootTableIndex {
+	LootTable: [LootTable!]!
+	LootTable_LootTableIndex: [LootTable!]!
+	LootTableIndex: Int
+}
+
+type Blueprints {
+	id: Int
+	name: String
+	description: String
+	accountid: Int
+	characterid: Int
+	price: Int
+	rating: Int
+	categoryid: Int
+	lxfpath: String
+	deleted: Int
+	created: Int
+	modified: Int
+}
+
+type mapShaders {
+	id: Int
+	label: String
+	gameValue: Int
+	priority: Int
+}
+
+type DBExclude {
+	table: String
+	column: String
+}
+
+type MinifigDecals_Torsos {
+	ID: Int
+	High_path: String
+	CharacterCreateValid: Int
+	male: Int
+	female: Int
+}
+
+type Objects {
+	MissionTaskObjects: [MissionTaskObjects!]!
+	MissionTaskObjects_object: [MissionTaskObjects!]!
+	BrickIDTable: [BrickIDTable!]!
+	BrickIDTable_NDObjectID: [BrickIDTable!]!
+	CelebrationParameters_backgroundObject: [CelebrationParameters!]!
+	CelebrationParameters_cameraPathLOT: [CelebrationParameters!]!
+	CurrencyDenominations: [CurrencyDenominations!]!
+	CurrencyDenominations_objectid: [CurrencyDenominations!]!
+	ActivityRewards: [ActivityRewards!]!
+	ActivityRewards_objectTemplate: [ActivityRewards!]!
+	InventoryComponent: [InventoryComponent!]!
+	InventoryComponent_itemid: [InventoryComponent!]!
+	JetPackPadComponent_lotBlocker: [JetPackPadComponent!]!
+	JetPackPadComponent_lotWarningVolume: [JetPackPadComponent!]!
+	LootTable: [LootTable!]!
+	LootTable_itemid: [LootTable!]!
+	LUPExhibitModelData: [LUPExhibitModelData!]!
+	LUPExhibitModelData_LOT: [LUPExhibitModelData!]!
+	mapIcon: [mapIcon!]!
+	mapIcon_LOT: [mapIcon!]!
+	ItemComponent_currencyLOT: [ItemComponent!]!
+	ItemComponent_commendationLOT: [ItemComponent!]!
+	MissionEmail: [MissionEmail!]!
+	MissionEmail_attachmentLOT: [MissionEmail!]!
+	Missions_offer_objectID: [Missions!]!
+	Missions_target_objectID: [Missions!]!
+	Missions_reward_item1: [Missions!]!
+	Missions_reward_item2: [Missions!]!
+	Missions_reward_item3: [Missions!]!
+	Missions_reward_item4: [Missions!]!
+	Missions_reward_item1_repeatable: [Missions!]!
+	Missions_reward_item2_repeatable: [Missions!]!
+	Missions_reward_item3_repeatable: [Missions!]!
+	Missions_reward_item4_repeatable: [Missions!]!
+	ModularBuildComponent: [ModularBuildComponent!]!
+	ModularBuildComponent_createdLOT: [ModularBuildComponent!]!
+	NpcIcons_LOT: [NpcIcons!]!
+	NpcIcons_compositeLOTMultiMission: [NpcIcons!]!
+	NpcIcons_compositeLOTMultiMissionVentor: [NpcIcons!]!
+	id: Int
+	name: String
+	placeable: Int
+	type: String
+	description: String
+	localize: Int
+	npcTemplateID: Int
+	displayName: String
+	interactionDistance: Float
+	nametag: Int
+	_internalNotes: String
+	locStatus: Int
+	gate_version: FeatureGating
+	HQ_valid: Int
+	description_loc: String
+	description_en_US: String
+	description_de_DE: String
+	description_en_GB: String
+	name_loc: String
+	name_en_US: String
+	name_de_DE: String
+	name_en_GB: String
+	itemComponent: ItemComponent
+	renderComponent: RenderComponent
+	ObjectSkills: [ObjectSkills!]!
+	ObjectSkills_objectTemplate: [ObjectSkills!]!
+	RebuildSections: [RebuildSections!]!
+	RebuildSections_objectID: [RebuildSections!]!
+	RewardCodes: [RewardCodes!]!
+	RewardCodes_attachmentLOT: [RewardCodes!]!
+	TamingBuildPuzzles_PuzzleModelLot: [TamingBuildPuzzles!]!
+	TamingBuildPuzzles_NPCLot: [TamingBuildPuzzles!]!
+	WhatsCoolItemSpotlight: [WhatsCoolItemSpotlight!]!
+	WhatsCoolItemSpotlight_itemID: [WhatsCoolItemSpotlight!]!
+}
+
+type PetNestComponent {
+	id: Int
+	ElementalType: Int
+}
+
+type brickAttributes {
+	ID: Int
+	icon_asset: String
+	display_order: Int
+	locStatus: Int
+	name_loc: String
+	name_en_US: String
+	name_de_DE: String
+	name_en_GB: String
+}
+
+type PropertyEntranceComponent {
+	id: Int
+	mapID: ZoneTable
+	propertyName: String
+	isOnProperty: Int
+	groupType: String
+}
+
+type Icons {
+	RenderComponent: [RenderComponent!]!
+	RenderComponent_IconID: [RenderComponent!]!
+	IconID: Int
+	IconPath: String
+	IconName: String
+	CelebrationParameters: [CelebrationParameters!]!
+	CelebrationParameters_iconID: [CelebrationParameters!]!
+	mapIcon: [mapIcon!]!
+	mapIcon_iconID: [mapIcon!]!
+	Missions: [Missions!]!
+	Missions_missionIconID: [Missions!]!
+	MissionTasks_IconID: [MissionTasks!]!
+	MissionTasks_largeTaskIconID: [MissionTasks!]!
+	MissionText_IconID: [MissionText!]!
+	MissionText_turnInIconID: [MissionText!]!
+	ProximityTypes: [ProximityTypes!]!
+	ProximityTypes_IconID: [ProximityTypes!]!
+	Preconditions: [Preconditions!]!
+	Preconditions_iconID: [Preconditions!]!
+	SkillBehavior: [SkillBehavior!]!
+	SkillBehavior_skillIcon: [SkillBehavior!]!
+	WhatsCoolNewsAndTips: [WhatsCoolNewsAndTips!]!
+	WhatsCoolNewsAndTips_iconID: [WhatsCoolNewsAndTips!]!
+}
+
+type ItemSets {
+	setID: Int
+	locStatus: Int
+	itemIDs: String
+	kitType: Int
+	kitRank: Int
+	kitImage: Int
+	skillSetWith2: Int
+	skillSetWith3: Int
+	skillSetWith4: Int
+	skillSetWith5: Int
+	skillSetWith6: Int
+	localize: Int
+	gate_version: String
+	kitID: Int
+	priority: Float
+	kitName_loc: String
+	kitName_en_US: String
+	kitName_de_DE: String
+	kitName_en_GB: String
+}
+
+type ObjectBehaviorXREF {
+	LOT: Int
+	behaviorID1: Int
+	behaviorID2: Int
+	behaviorID3: Int
+	behaviorID4: Int
+	behaviorID5: Int
+	type: Int
+}
+
+type RenderComponentWrapper {
+	id: Int
+	defaultWrapperAsset: String
+}
+
+type ControlSchemes {
+	control_scheme: Int
+	scheme_name: String
+	rotation_speed: Float
+	walk_forward_speed: Float
+	walk_backward_speed: Float
+	walk_strafe_speed: Float
+	walk_strafe_forward_speed: Float
+	walk_strafe_backward_speed: Float
+	run_backward_speed: Float
+	run_strafe_speed: Float
+	run_strafe_forward_speed: Float
+	run_strafe_backward_speed: Float
+	keyboard_zoom_sensitivity: Float
+	keyboard_pitch_sensitivity: Float
+	keyboard_yaw_sensitivity: Float
+	mouse_zoom_wheel_sensitivity: Float
+	x_mouse_move_sensitivity_modifier: Float
+	y_mouse_move_sensitivity_modifier: Float
+	freecam_speed_modifier: Float
+	freecam_slow_speed_multiplier: Float
+	freecam_fast_speed_multiplier: Float
+	freecam_mouse_modifier: Float
+	gamepad_pitch_rot_sensitivity: Float
+	gamepad_yaw_rot_sensitivity: Float
+	gamepad_trigger_sensitivity: Float
+	PossessableComponent: [PossessableComponent!]!
+	PossessableComponent_controlSchemeID: [PossessableComponent!]!
+}
+
+type DevModelBehaviors {
+	ModelID: Int
+	BehaviorID: Int
+}
+
+type BaseCombatAIComponent {
+	id: Int
+	behaviorType: Int
+	combatRoundLength: Float
+	combatRole: Int
+	minRoundLength: Float
+	maxRoundLength: Float
+	tetherSpeed: Float
+	pursuitSpeed: Float
+	combatStartDelay: Float
+	softTetherRadius: Float
+	hardTetherRadius: Float
+	spawnTimer: Float
+	tetherEffectID: Int
+	ignoreMediator: Int
+	aggroRadius: Float
+	ignoreStatReset: Int
+	ignoreParent: Int
+}
+
+type BrickIDTable {
+	NDObjectID: Objects
+	LEGOBrickID: Int
+}
+
+type LUPExhibitComponent {
+	id: Int
+	minXZ: Float
+	maxXZ: Float
+	maxY: Float
+	offsetX: Float
+	offsetY: Float
+	offsetZ: Float
+}
+
+type MinifigDecals_Legs {
+	ID: Int
+	High_path: String
+}
+
+type DestructibleComponent {
+	id: Int
+	faction: Factions
+	factionList: String
+	life: Int
+	imagination: Int
+	LootMatrixIndex: LootMatrix
+	CurrencyIndex: Int
+	level: Int
+	armor: Float
+	death_behavior: Int
+	isnpc: Int
+	attack_priority: Int
+	isSmashable: Int
+	difficultyLevel: Int
+}
+
+type SceneTable {
+	sceneID: Int
+	sceneName: String
+}
+
+type RenderComponentFlash {
+	id: Int
+	interactive: Int
+	animated: Int
+	nodeName: String
+	flashPath: String
+	elementName: String
+	_uid: Int
+}
+
+type ItemFoodData {
+	id: Int
+	element_1: Int
+	element_1_amount: Int
+	element_2: Int
+	element_2_amount: Int
+	element_3: Int
+	element_3_amount: Int
+	element_4: Int
+	element_4_amount: Int
+}
+
+type SpeedchatMenu {
+	id: Int
+	parentId: Int
+	emoteId: Emotes
+	imageName: String
+	localize: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	menuText_loc: String
+	menuText_en_US: String
+	menuText_de_DE: String
+	menuText_en_GB: String
+}
+
+type JetPackPadComponent {
+	id: Int
+	xDistance: Float
+	yDistance: Float
+	warnDistance: Float
+	lotBlocker: Objects
+	lotWarningVolume: Objects
+}
+
+type mapIcon {
+	LOT: Objects
+	iconID: Icons
+	iconState: Int
+}
+
+type dtproperties {
+	id: Int
+	objectid: Int
+	property: String
+	value: String
+	uvalue: String
+	lvalue: String
+	version: Int
+}
+
+type LootTable {
+	LootMatrix: [LootMatrix!]!
+	LootMatrix_LootTableIndex: [LootMatrix!]!
+	itemid: Objects
+	LootTableIndex: LootTableIndex
+	id: Int
+	MissionDrop: Int
+	sortPriority: Int
+}
+
+type mapItemTypes {
+	id: Int
+	description: String
+	equipLocation: String
+	ItemComponent: [ItemComponent!]!
+	ItemComponent_itemType: [ItemComponent!]!
+}
+
+type MissionText {
+	id: Missions
+	story_icon: String
+	missionIcon: String
+	offerNPCIcon: String
+	IconID: Icons
+	state_1_anim: String
+	state_2_anim: String
+	state_3_anim: String
+	state_4_anim: String
+	state_3_turnin_anim: String
+	state_4_turnin_anim: String
+	onclick_anim: String
+	CinematicAccepted: String
+	CinematicAcceptedLeadin: Float
+	CinematicCompleted: String
+	CinematicCompletedLeadin: Float
+	CinematicRepeatable: String
+	CinematicRepeatableLeadin: Float
+	CinematicRepeatableCompleted: String
+	CinematicRepeatableCompletedLeadin: Float
+	AudioEventGUID_Interact: String
+	AudioEventGUID_OfferAccept: String
+	AudioEventGUID_OfferDeny: String
+	AudioEventGUID_Completed: String
+	AudioEventGUID_TurnIn: String
+	AudioEventGUID_Failed: String
+	AudioEventGUID_Progress: String
+	AudioMusicCue_OfferAccept: String
+	AudioMusicCue_TurnIn: String
+	turnInIconID: Icons
+	localize: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	accept_chat_bubble_loc: String
+	accept_chat_bubble_en_US: String
+	accept_chat_bubble_de_DE: String
+	accept_chat_bubble_en_GB: String
+	chat_state_1_loc: String
+	chat_state_1_en_US: String
+	chat_state_1_de_DE: String
+	chat_state_1_en_GB: String
+	chat_state_2_loc: String
+	chat_state_2_en_US: String
+	chat_state_2_de_DE: String
+	chat_state_2_en_GB: String
+	chat_state_3_turnin_loc: String
+	chat_state_3_turnin_en_US: String
+	chat_state_3_turnin_de_DE: String
+	chat_state_3_turnin_en_GB: String
+	completion_succeed_tip_loc: String
+	completion_succeed_tip_en_US: String
+	completion_succeed_tip_de_DE: String
+	completion_succeed_tip_en_GB: String
+	in_progress_loc: String
+	in_progress_en_US: String
+	in_progress_de_DE: String
+	in_progress_en_GB: String
+	offer_loc: String
+	offer_en_US: String
+	offer_de_DE: String
+	offer_en_GB: String
+	ready_to_complete_loc: String
+	ready_to_complete_en_US: String
+	ready_to_complete_de_DE: String
+	ready_to_complete_en_GB: String
+	description_loc: String
+	description_en_US: String
+	description_de_DE: String
+	description_en_GB: String
+	chat_state_3_loc: String
+	chat_state_3_en_US: String
+	chat_state_3_de_DE: String
+	chat_state_3_en_GB: String
+	chat_state_4_loc: String
+	chat_state_4_en_US: String
+	chat_state_4_de_DE: String
+	chat_state_4_en_GB: String
+	chat_state_4_turnin_loc: String
+	chat_state_4_turnin_en_US: String
+	chat_state_4_turnin_de_DE: String
+	chat_state_4_turnin_en_GB: String
+	offer_repeatable_loc: String
+	offer_repeatable_en_US: String
+	offer_repeatable_de_DE: String
+	offer_repeatable_en_GB: String
+}
+
+type PhysicsComponent {
+	id: Int
+	static: Float
+	physics_asset: String
+	jump: Float
+	doublejump: Float
+	speed: Float
+	rotSpeed: Float
+	playerHeight: Float
+	playerRadius: Float
+	pcShapeType: Int
+	collisionGroup: Int
+	airSpeed: Float
+	boundaryAsset: String
+	jumpAirSpeed: Float
+	friction: Float
+	gravityVolumeAsset: String
+}
+
+type ReputationRewards {
+	repLevel: Int
+	sublevel: Int
+	reputation: Float
+}
+
+type RarityTable {
+	id: Int
+	randmax: Float
+	rarity: Int
+	RarityTableIndex: RarityTableIndex
+	SmashableChain: [SmashableChain!]!
+	SmashableChain_rarityTableIndex: [SmashableChain!]!
+}
+
+type MinifigDecals_Eyebrows {
+	ID: Int
+	High_path: String
+	Low_path: String
+	CharacterCreateValid: Int
+	male: Int
+	female: Int
+	MinifigComponent: [MinifigComponent!]!
+	MinifigComponent_eyebrowstyle: [MinifigComponent!]!
+}
+
+type CollectibleComponent {
+	id: Int
+	requirement_mission: Missions
+}
+
+type RocketLaunchpadControlComponent {
+	id: Int
+	targetZone: ZoneTable
+	defaultZoneID: ZoneTable
+	targetScene: String
+	gmLevel: Int
+	playerAnimation: String
+	rocketAnimation: String
+	launchMusic: String
+	useLaunchPrecondition: Int
+	useAltLandingPrecondition: Int
+	launchPrecondition: String
+	altLandingPrecondition: String
+	altLandingSpawnPointName: String
+}
+
+type PlayerFlags {
+	id: Int
+	SessionOnly: Int
+	OnlySetByServer: Int
+	SessionZoneOnly: Int
+}
+
+type SmashableChainIndex {
+	id: Int
+	targetGroup: String
+	description: String
+	continuous: Int
+}
+
+type PetAbilities {
+	id: Int
+	AbilityName: String
+	ImaginationCost: Int
+	locStatus: Int
+	DisplayName_loc: String
+	DisplayName_en_US: String
+	DisplayName_de_DE: String
+	DisplayName_en_GB: String
+}
+
+type mapAnimationPriorities {
+	id: Int
+	name: String
+	priority: Float
+}
+
+type RewardCodes {
+	id: Int
+	code: String
+	attachmentLOT: Objects
+	locStatus: Int
+	gate_version: FeatureGating
+	bodyText_loc: String
+	bodyText_en_US: String
+	bodyText_de_DE: String
+	bodyText_en_GB: String
+	subjectText_loc: String
+	subjectText_en_US: String
+	subjectText_de_DE: String
+	subjectText_en_GB: String
+}
+
+type RailActivatorComponent {
+	id: Int
+	startAnim: String
+	loopAnim: String
+	stopAnim: String
+	startSound: String
+	loopSound: String
+	stopSound: String
+	effectIDs: String
+	preconditions: String
+	playerCollision: Int
+	cameraLocked: Int
+	StartEffectID: String
+	StopEffectID: String
+	DamageImmune: Int
+	NoAggro: Int
+	ShowNameBillboard: Int
+}
+
+type PropertyTemplate {
+	id: Int
+	mapID: ZoneTable
+	vendorMapID: ZoneTable
+	spawnName: String
+	type: Int
+	sizecode: Int
+	minimumPrice: Int
+	rentDuration: Int
+	path: String
+	cloneLimit: Int
+	durationType: Int
+	achievementRequired: Int
+	zoneX: Float
+	zoneY: Float
+	zoneZ: Float
+	maxBuildHeight: Float
+	localize: Int
+	reputationPerMinute: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	description_loc: String
+	description_en_US: String
+	description_de_DE: String
+	description_en_GB: String
+	name_loc: String
+	name_en_US: String
+	name_de_DE: String
+	name_en_GB: String
+}
+
+type AICombatRoles {
+	id: Int
+	preferredRole: Int
+	specifiedMinRangeNOUSE: Float
+	specifiedMaxRangeNOUSE: Float
+	specificMinRange: Float
+	specificMaxRange: Float
+}
+
+type MinifigDecals_Eyes {
+	ID: Int
+	High_path: String
+	Low_path: String
+	CharacterCreateValid: Int
+	male: Int
+	female: Int
+	MinifigComponent: [MinifigComponent!]!
+	MinifigComponent_eyesstyle: [MinifigComponent!]!
+}
+
+type MinifigDecals_Mouths {
+	ID: Int
+	High_path: String
+	Low_path: String
+	CharacterCreateValid: Int
+	male: Int
+	female: Int
+	MinifigComponent: [MinifigComponent!]!
+	MinifigComponent_mouthstyle: [MinifigComponent!]!
+}
+
+type mapTextureResource {
+	id: Int
+	texturepath: String
+	SurfaceType: Int
+}
+
+type Camera {
+	camera_name: String
+	pitch_angle_tolerance: Float
+	starting_zoom: Float
+	zoom_return_modifier: Float
+	pitch_return_modifier: Float
+	tether_out_return_modifier: Float
+	tether_in_return_multiplier: Float
+	verticle_movement_dampening_modifier: Float
+	return_from_incline_modifier: Float
+	horizontal_return_modifier: Float
+	yaw_behavior_speed_multiplier: Float
+	camera_collision_padding: Float
+	glide_speed: Float
+	fade_player_min_range: Float
+	min_movement_delta_tolerance: Float
+	min_glide_distance_tolerance: Float
+	look_forward_offset: Float
+	look_up_offset: Float
+	minimum_vertical_dampening_distance: Float
+	maximum_vertical_dampening_distance: Float
+	minimum_ignore_jump_distance: Float
+	maximum_ignore_jump_distance: Float
+	maximum_auto_glide_angle: Float
+	minimum_tether_glide_distance: Float
+	yaw_sign_correction: Float
+	set_1_look_forward_offset: Float
+	set_1_look_up_offset: Float
+	set_2_look_forward_offset: Float
+	set_2_look_up_offset: Float
+	set_0_speed_influence_on_dir: Float
+	set_1_speed_influence_on_dir: Float
+	set_2_speed_influence_on_dir: Float
+	set_0_angular_relaxation: Float
+	set_1_angular_relaxation: Float
+	set_2_angular_relaxation: Float
+	set_0_position_up_offset: Float
+	set_1_position_up_offset: Float
+	set_2_position_up_offset: Float
+	set_0_position_forward_offset: Float
+	set_1_position_forward_offset: Float
+	set_2_position_forward_offset: Float
+	set_0_FOV: Float
+	set_1_FOV: Float
+	set_2_FOV: Float
+	set_0_max_yaw_angle: Float
+	set_1_max_yaw_angle: Float
+	set_2_max_yaw_angle: Float
+	set_1_fade_in_camera_set_change: Int
+	set_1_fade_out_camera_set_change: Int
+	set_2_fade_in_camera_set_change: Int
+	set_2_fade_out_camera_set_change: Int
+	input_movement_scalar: Float
+	input_rotation_scalar: Float
+	input_zoom_scalar: Float
+	minimum_pitch_desired: Float
+	maximum_pitch_desired: Float
+	minimum_zoom: Float
+	maximum_zoom: Float
+	horizontal_rotate_tolerance: Float
+	horizontal_rotate_modifier: Float
+}
+
+type ModuleComponent {
+	id: Int
+	partCode: Int
+	buildType: Int
+	xml: String
+	primarySoundGUID: String
+	assembledEffectID: Int
+}
+
+type ActivityText {
+	activityID: Activities
+	type: String
+	localize: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	broadcast_subjectText_loc: String
+	broadcast_subjectText_en_US: String
+	broadcast_subjectText_de_DE: String
+	broadcast_subjectText_en_GB: String
+	broadcast_text_loc: String
+	broadcast_text_en_US: String
+	broadcast_text_de_DE: String
+	broadcast_text_en_GB: String
+	mail_subjectText_loc: String
+	mail_subjectText_en_US: String
+	mail_subjectText_de_DE: String
+	mail_subjectText_en_GB: String
+	mail_text_loc: String
+	mail_text_en_US: String
+	mail_text_de_DE: String
+	mail_text_en_GB: String
+	hint10_text_loc: String
+	hint10_text_en_US: String
+	hint10_text_de_DE: String
+	hint10_text_en_GB: String
+	hint11_text_loc: String
+	hint11_text_en_US: String
+	hint11_text_de_DE: String
+	hint11_text_en_GB: String
+	hint1_text_loc: String
+	hint1_text_en_US: String
+	hint1_text_de_DE: String
+	hint1_text_en_GB: String
+	hint2_text_loc: String
+	hint2_text_en_US: String
+	hint2_text_de_DE: String
+	hint2_text_en_GB: String
+	hint3_text_loc: String
+	hint3_text_en_US: String
+	hint3_text_de_DE: String
+	hint3_text_en_GB: String
+	hint4_text_loc: String
+	hint4_text_en_US: String
+	hint4_text_de_DE: String
+	hint4_text_en_GB: String
+	hint5_text_loc: String
+	hint5_text_en_US: String
+	hint5_text_de_DE: String
+	hint5_text_en_GB: String
+	hint6_text_loc: String
+	hint6_text_en_US: String
+	hint6_text_de_DE: String
+	hint6_text_en_GB: String
+	hint7_text_loc: String
+	hint7_text_en_US: String
+	hint7_text_de_DE: String
+	hint7_text_en_GB: String
+	hint8_text_loc: String
+	hint8_text_en_US: String
+	hint8_text_de_DE: String
+	hint8_text_en_GB: String
+	hint9_text_loc: String
+	hint9_text_en_US: String
+	hint9_text_de_DE: String
+	hint9_text_en_GB: String
+}
+
+type Preconditions {
+	id: Int
+	type: Int
+	targetLOT: String
+	targetGroup: String
+	targetCount: Int
+	iconID: Icons
+	localize: Int
+	validContexts: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	FailureReason_loc: String
+	FailureReason_en_US: String
+	FailureReason_de_DE: String
+	FailureReason_en_GB: String
+}
+
+type ScriptComponent {
+	id: Int
+	script_name: String
+	client_script_name: String
+}
+
+type UGBehaviorSounds {
+	id: Int
+	guid: String
+	localize: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	name_loc: String
+	name_en_US: String
+	name_de_DE: String
+	name_en_GB: String
+}
+
+type WhatsCoolNewsAndTips {
+	id: Int
+	iconID: Icons
+	type: Int
+	localize: Int
+	gate_version: FeatureGating
+	locStatus: Int
+	storyTitle_loc: String
+	storyTitle_en_US: String
+	storyTitle_de_DE: String
+	storyTitle_en_GB: String
+	text_loc: String
+	text_en_US: String
+	text_de_DE: String
+	text_en_GB: String
+}
+
+type ModelBehavior {
+	id: Int
+	definitionXMLfilename: String
+}
+
+type AnimationIndex {
+	animationGroupID: Int
+	description: String
+	groupType: String
+}
+
+type RacingModuleComponent {
+	id: Int
+	topSpeed: Float
+	acceleration: Float
+	handling: Float
+	stability: Float
+	imagination: Float
+}
+
+type BuffParameters {
+	BuffID: BuffDefinitions
+	ParameterName: String
+	NumberValue: Float
+	StringValue: String
+	EffectID: Int
+}
+
+type RenderComponent {
+	id: Int
+	render_asset: String
+	icon_asset: String
+	IconID: Icons
+	shader_id: Int
+	effect1: Int
+	effect2: Int
+	effect3: Int
+	effect4: Int
+	effect5: Int
+	effect6: Int
+	animationGroupIDs: String
+	fade: Int
+	usedropshadow: Int
+	preloadAnimations: Int
+	fadeInTime: Float
+	maxShadowDistance: Float
+	ignoreCameraCollision: Int
+	renderComponentLOD1: Int
+	renderComponentLOD2: Int
+	gradualSnap: Int
+	animationFlag: Int
+	AudioMetaEventSet: String
+	billboardHeight: Float
+	chatBubbleOffset: Float
+	staticBillboard: Int
+	LXFMLFolder: String
+	attachIndicatorsToNode: Int
+	Objects: [Objects!]!
+	Objects_renderComponent: [Objects!]!
+}
+
+type RenderIconAssets {
+	id: Int
+	icon_asset: String
+	blank_column: String
+}
+
+type FlairTable {
+	id: Int
+	asset: String
+}
+
+type MotionFX {
+	id: Int
+	typeID: Int
+	slamVelocity: Float
+	addVelocity: Float
+	duration: Float
+	destGroupName: String
+	startScale: Float
+	endScale: Float
+	velocity: Float
+	distance: Float
+}
+
+type TrailEffects {
+	trailID: Int
+	textureName: String
+	blendmode: Int
+	cardlifetime: Float
+	colorlifetime: Float
+	minTailFade: Float
+	tailFade: Float
+	max_particles: Int
+	birthDelay: Float
+	deathDelay: Float
+	bone1: String
+	bone2: String
+	texLength: Float
+	texWidth: Float
+	startColorR: Float
+	startColorG: Float
+	startColorB: Float
+	startColorA: Float
+	middleColorR: Float
+	middleColorG: Float
+	middleColorB: Float
+	middleColorA: Float
+	endColorR: Float
+	endColorG: Float
+	endColorB: Float
+	endColorA: Float
+}
+
+type map_BlueprintCategory {
+	id: Int
+	description: String
+	enabled: Int
+}
+
+type EventGating {
+	eventName: String
+	date_start: Int
+	date_end: Int
+}
+
+type SurfaceType {
+	SurfaceType: Int
+	FootstepNDAudioMetaEventSetName: String
+}
+
+type ModularBuildComponent {
+	id: Int
+	buildType: Int
+	xml: String
+	createdLOT: Objects
+	createdPhysicsID: Int
+	AudioEventGUID_Snap: String
+	AudioEventGUID_Complete: String
+	AudioEventGUID_Present: String
+}
+
+type ObjectSkills {
+	objectTemplate: Objects
+	skillID: SkillBehavior
+	castOnType: Int
+	AICombatWeight: Int
+}
+
+type VendorComponent {
+	id: Int
+	buyScalar: Float
+	sellScalar: Float
+	refreshTimeSeconds: Float
+	LootMatrixIndex: LootMatrix
+}
+
+type MissionTasks {
+	MissionTaskObjects: [MissionTaskObjects!]!
+	MissionTaskObjects_missionTask: [MissionTaskObjects!]!
+	MissionTaskMissions: [MissionTaskMissions!]!
+	MissionTaskMissions_missionTask: [MissionTaskMissions!]!
+	id: Missions
+	locStatus: Int
+	taskType: Int
+	target: Int
+	targetGroup: String
+	targetValue: Int
+	taskParam1: String
+	largeTaskIcon: String
+	IconID: Icons
+	uid: Int
+	largeTaskIconID: Icons
+	localize: Int
+	gate_version: FeatureGating
+	description_loc: String
+	description_en_US: String
+	description_de_DE: String
+	description_en_GB: String
+}
+
+type SubscriptionPricing {
+	id: Int
+	countryCode: String
+	monthlyFeeGold: String
+	monthlyFeeSilver: String
+	monthlyFeeBronze: String
+	monetarySymbol: Int
+	symbolIsAppended: Int
+}
+
+type ProximityMonitorComponent {
+	id: Int
+	Proximities: String
+	LoadOnClient: Int
+	LoadOnServer: Int
+}
+
+type RebuildComponent {
+	id: Int
+	reset_time: Float
+	complete_time: Float
+	take_imagination: Int
+	interruptible: Int
+	self_activator: Int
+	custom_modules: String
+	activityID: Activities
+	post_imagination_cost: Int
+	time_before_smash: Float
+}
+
+type BuffDefinitions {
+	ID: Int
+	Priority: Float
+	UIIcon: String
+	BuffParameters: [BuffParameters!]!
+	BuffParameters_BuffID: [BuffParameters!]!
+}
+
+type sysdiagrams {
+	name: String
+	principal_id: Int
+	diagram_id: Int
+	version: Int
+	definition: String
+}
+
+type LevelProgressionLookup {
+	id: Int
+	requiredUScore: Int
+	BehaviorEffect: String
+}
+
+type TextDescription {
+	TextID: Int
+	TestDescription: String
+}
+
+type VehiclePhysics {
+	id: Int
+	hkxFilename: String
+	fGravityScale: Float
+	fMass: Float
+	fChassisFriction: Float
+	fMaxSpeed: Float
+	fEngineTorque: Float
+	fBrakeFrontTorque: Float
+	fBrakeRearTorque: Float
+	fBrakeMinInputToBlock: Float
+	fBrakeMinTimeToBlock: Float
+	fSteeringMaxAngle: Float
+	fSteeringSpeedLimitForMaxAngle: Float
+	fSteeringMinAngle: Float
+	fFwdBias: Float
+	fFrontTireFriction: Float
+	fRearTireFriction: Float
+	fFrontTireFrictionSlide: Float
+	fRearTireFrictionSlide: Float
+	fFrontTireSlipAngle: Float
+	fRearTireSlipAngle: Float
+	fWheelWidth: Float
+	fWheelRadius: Float
+	fWheelMass: Float
+	fReorientPitchStrength: Float
+	fReorientRollStrength: Float
+	fSuspensionLength: Float
+	fSuspensionStrength: Float
+	fSuspensionDampingCompression: Float
+	fSuspensionDampingRelaxation: Float
+	iChassisCollisionGroup: Int
+	fNormalSpinDamping: Float
+	fCollisionSpinDamping: Float
+	fCollisionThreshold: Float
+	fTorqueRollFactor: Float
+	fTorquePitchFactor: Float
+	fTorqueYawFactor: Float
+	fInertiaRoll: Float
+	fInertiaPitch: Float
+	fInertiaYaw: Float
+	fExtraTorqueFactor: Float
+	fCenterOfMassFwd: Float
+	fCenterOfMassUp: Float
+	fCenterOfMassRight: Float
+	fWheelHardpointFrontFwd: Float
+	fWheelHardpointFrontUp: Float
+	fWheelHardpointFrontRight: Float
+	fWheelHardpointRearFwd: Float
+	fWheelHardpointRearUp: Float
+	fWheelHardpointRearRight: Float
+	fInputTurnSpeed: Float
+	fInputDeadTurnBackSpeed: Float
+	fInputAccelSpeed: Float
+	fInputDeadAccelDownSpeed: Float
+	fInputDecelSpeed: Float
+	fInputDeadDecelDownSpeed: Float
+	fInputSlopeChangePointX: Float
+	fInputInitialSlope: Float
+	fInputDeadZone: Float
+	fAeroAirDensity: Float
+	fAeroFrontalArea: Float
+	fAeroDragCoefficient: Float
+	fAeroLiftCoefficient: Float
+	fAeroExtraGravity: Float
+	fBoostTopSpeed: Float
+	fBoostCostPerSecond: Float
+	fBoostAccelerateChange: Float
+	fBoostDampingChange: Float
+	fPowerslideNeutralAngle: Float
+	fPowerslideTorqueStrength: Float
+	iPowerslideNumTorqueApplications: Int
+	fImaginationTankSize: Float
+	fSkillCost: Float
+	fWreckSpeedBase: Float
+	fWreckSpeedPercent: Float
+	fWreckMinAngle: Float
+	AudioEventEngine: String
+	AudioEventSkid: String
+	AudioEventLightHit: String
+	AudioSpeedThresholdLightHit: Float
+	AudioTimeoutLightHit: Float
+	AudioEventHeavyHit: String
+	AudioSpeedThresholdHeavyHit: Float
+	AudioTimeoutHeavyHit: Float
+	AudioEventStart: String
+	AudioEventTreadConcrete: String
+	AudioEventTreadSand: String
+	AudioEventTreadWood: String
+	AudioEventTreadDirt: String
+	AudioEventTreadPlastic: String
+	AudioEventTreadGrass: String
+	AudioEventTreadGravel: String
+	AudioEventTreadMud: String
+	AudioEventTreadWater: String
+	AudioEventTreadSnow: String
+	AudioEventTreadIce: String
+	AudioEventTreadMetal: String
+	AudioEventTreadLeaves: String
+	AudioEventLightLand: String
+	AudioAirtimeForLightLand: Float
+	AudioEventHeavyLand: String
+	AudioAirtimeForHeavyLand: Float
+	bWheelsVisible: Int
+}
+
+type PetComponent {
+	id: Int
+	minTameUpdateTime: Float
+	maxTameUpdateTime: Float
+	percentTameChance: Float
+	tamability: Float
+	elementType: Int
+	walkSpeed: Float
+	runSpeed: Float
+	sprintSpeed: Float
+	idleTimeMin: Float
+	idleTimeMax: Float
+	petForm: Int
+	imaginationDrainRate: Float
+	AudioMetaEventSet: String
+	buffIDs: String
+}
+
+type ObjectBehaviors {
+	BehaviorID: Int
+	xmldata: String
+}
+
+type PossessableComponent {
+	id: Int
+	controlSchemeID: ControlSchemes
+	minifigAttachPoint: String
+	minifigAttachAnimation: String
+	minifigDetachAnimation: String
+	mountAttachAnimation: String
+	mountDetachAnimation: String
+	attachOffsetFwd: Float
+	attachOffsetRight: Float
+	possessionType: Int
+	wantBillboard: Int
+	billboardOffsetUp: Float
+	depossessOnHit: Int
+	hitStunTime: Float
+	skillSet: Int
+}
+
+type BehaviorEffect {
+	effectID: Int
+	effectType: String
+	effectName: String
+	trailID: Int
+	pcreateDuration: Float
+	animationName: String
+	attachToObject: Int
+	boneName: String
+	useSecondary: Int
+	cameraEffectType: Int
+	cameraDuration: Float
+	cameraFrequency: Float
+	cameraXAmp: Float
+	cameraYAmp: Float
+	cameraZAmp: Float
+	cameraRotFrequency: Float
+	cameraRoll: Float
+	cameraPitch: Float
+	cameraYaw: Float
+	AudioEventGUID: String
+	renderEffectType: Int
+	renderEffectTime: Float
+	renderStartVal: Float
+	renderEndVal: Float
+	renderDelayVal: Float
+	renderValue1: Float
+	renderValue2: Float
+	renderValue3: Float
+	renderRGBA: String
+	renderShaderVal: Int
+	motionID: Int
+	meshID: Int
+	meshDuration: Float
+	meshLockedNode: String
+}
+
+type LootMatrixIndex {
+	LootMatrixIndex: Int
+	inNpcEditor: Int
+	LootMatrix: [LootMatrix!]!
+	LootMatrix_LootMatrixIndex: [LootMatrix!]!
+}
+
+type VehicleStatMap {
+	id: Int
+	ModuleStat: String
+	HavokStat: String
+	HavokChangePerModuleStat: Float
+}
+
+type MovingPlatforms {
+	id: Int
+	platformIsSimpleMover: Int
+	platformMoveX: Float
+	platformMoveY: Float
+	platformMoveZ: Float
+	platformMoveTime: Float
+	platformStartAtEnd: Int
+	description: String
+}
+
+type MissionTaskMissions {
+	missionTask: MissionTasks!
+	mission: Missions!
+}
+
+type Factions {
+	DestructibleComponent: [DestructibleComponent!]!
+	DestructibleComponent_faction: [DestructibleComponent!]!
+	faction: Int
+	factionList: String
+	factionListFriendly: Int
+	friendList: String
+	enemyList: String
+}
+
+type SkillBehavior {
+	ItemSetSkills: [ItemSetSkills!]!
+	ItemSetSkills_SkillID: [ItemSetSkills!]!
+	ObjectSkills: [ObjectSkills!]!
+	ObjectSkills_skillID: [ObjectSkills!]!
+	skillID: Int
+	locStatus: Int
+	behaviorID: Int
+	imaginationcost: Int
+	cooldowngroup: Int
+	cooldown: Float
+	inNpcEditor: Int
+	skillIcon: Icons
+	oomSkillID: String
+	oomBehaviorEffectID: Int
+	castTypeDesc: Int
+	imBonusUI: Int
+	lifeBonusUI: Int
+	armorBonusUI: Int
+	damageUI: Int
+	hideIcon: Int
+	localize: Int
+	gate_version: FeatureGating
+	cancelType: Int
+	descriptionUI_loc: String
+	descriptionUI_en_US: String
+	descriptionUI_de_DE: String
+	descriptionUI_en_GB: String
+	name_loc: String
+	name_en_US: String
+	name_de_DE: String
+	name_en_GB: String
+}
+
+type Activities {
+	ActivityID: Int
+	locStatus: Int
+	instanceMapID: ZoneTable
+	minTeams: Int
+	maxTeams: Int
+	minTeamSize: Int
+	maxTeamSize: Int
+	waitTime: Int
+	startDelay: Int
+	requiresUniqueData: Int
+	leaderboardType: Int
+	localize: Int
+	optionalCostLOT: Int
+	optionalCostCount: Int
+	showUIRewards: Int
+	CommunityActivityFlagID: Int
+	gate_version: FeatureGating
+	noTeamLootOnDeath: Int
+	optionalPercentage: Float
+	ActivityName_loc: String
+	ActivityName_en_US: String
+	ActivityName_de_DE: String
+	ActivityName_en_GB: String
+	ActivityText: [ActivityText!]!
+	ActivityText_activityID: [ActivityText!]!
+	RebuildComponent: [RebuildComponent!]!
+	RebuildComponent_activityID: [RebuildComponent!]!
+}
+
+type SmashableComponent {
+	id: Int
+	LootMatrixIndex: LootMatrix
+}
+
+type TamingBuildPuzzles {
+	id: Int
+	PuzzleModelLot: Objects
+	NPCLot: Objects
+	ValidPiecesLXF: String
+	InvalidPiecesLXF: String
+	Difficulty: Int
+	Timelimit: Int
+	NumValidPieces: Int
+	TotalNumPieces: Int
+	ModelName: String
+	FullModelLXF: String
+	Duration: Float
+	imagCostPerBuild: Int
+}
+
+type Animations {
+	animationGroupID: Int
+	animation_type: String
+	animation_name: String
+	chance_to_play: Float
+	min_loops: Int
+	max_loops: Int
+	animation_length: Float
+	hideEquip: Int
+	ignoreUpperBody: Int
+	restartable: Int
+	face_animation_name: String
+	priority: Float
+	blendTime: Float
+}
+
+type NpcIcons {
+	id: Int
+	color: Int
+	offset: Float
+	LOT: Objects
+	Texture: String
+	isClickable: Int
+	scale: Float
+	rotateToFace: Int
+	compositeHorizOffset: Float
+	compositeVertOffset: Float
+	compositeScale: Float
+	compositeConnectionNode: String
+	compositeLOTMultiMission: Objects
+	compositeLOTMultiMissionVentor: Objects
+	compositeIconTexture: String
+}
+
+type SmashableElements {
+	elementID: Int
+	dropWeight: Int
+}
+
+type Rewards {
+	id: Int
+	LevelID: Int
+	MissionID: Int
+	RewardType: Int
+	value: Int
+	count: Int
+}
+
+type BehaviorTemplate {
+	behaviorID: Int
+	templateID: BehaviorTemplateName
+	effectID: Int
+	effectHandle: String
+}
+
+type SmashableChain {
+	chainIndex: Int
+	chainLevel: Int
+	lootMatrixID: LootMatrix
+	rarityTableIndex: RarityTable
+	currencyIndex: Int
+	currencyLevel: Int
+	smashCount: Int
+	timeLimit: Int
+	chainStepID: Int
+}
+
+type Release_Version {
+	ReleaseVersion: String
+	ReleaseDate: Int
+}
+
+type WorldConfig {
+	WorldConfigID: Int
+	pegravityvalue: Float
+	pebroadphaseworldsize: Float
+	pegameobjscalefactor: Float
+	character_rotation_speed: Float
+	character_walk_forward_speed: Float
+	character_walk_backward_speed: Float
+	character_walk_strafe_speed: Float
+	character_walk_strafe_forward_speed: Float
+	character_walk_strafe_backward_speed: Float
+	character_run_backward_speed: Float
+	character_run_strafe_speed: Float
+	character_run_strafe_forward_speed: Float
+	character_run_strafe_backward_speed: Float
+	global_cooldown: Float
+	characterGroundedTime: Float
+	characterGroundedSpeed: Float
+	globalImmunityTime: Float
+	character_max_slope: Float
+	defaultrespawntime: Float
+	mission_tooltip_timeout: Float
+	vendor_buy_multiplier: Float
+	pet_follow_radius: Float
+	character_eye_height: Float
+	flight_vertical_velocity: Float
+	flight_airspeed: Float
+	flight_fuel_ratio: Float
+	flight_max_airspeed: Float
+	fReputationPerVote: Float
+	nPropertyCloneLimit: Int
+	defaultHomespaceTemplate: Int
+	coins_lost_on_death_percent: Float
+	coins_lost_on_death_min: Int
+	coins_lost_on_death_max: Int
+	character_votes_per_day: Int
+	property_moderation_request_approval_cost: Int
+	property_moderation_request_review_cost: Int
+	propertyModRequestsAllowedSpike: Int
+	propertyModRequestsAllowedInterval: Int
+	propertyModRequestsAllowedTotal: Int
+	propertyModRequestsSpikeDuration: Int
+	propertyModRequestsIntervalDuration: Int
+	modelModerateOnCreate: Int
+	defaultPropertyMaxHeight: Float
+	reputationPerVoteCast: Float
+	reputationPerVoteReceived: Float
+	showcaseTopModelConsiderationBattles: Int
+	reputationPerBattlePromotion: Float
+	coins_lost_on_death_min_timeout: Float
+	coins_lost_on_death_max_timeout: Float
+	mail_base_fee: Int
+	mail_percent_attachment_fee: Float
+	propertyReputationDelay: Int
+	LevelCap: Int
+	LevelUpBehaviorEffect: String
+	CharacterVersion: Int
+	LevelCapCurrencyConversion: Int
+}
+
+type MissionTaskObjects {
+	missionTask: MissionTasks!
+	object: Objects!
+}
+
+type LanguageType {
+	LanguageID: Int
+	LanguageDescription: String
+}
+
+type CurrencyTable {
+	currencyIndex: Int
+	npcminlevel: Int
+	minvalue: Int
+	maxvalue: Int
+	id: Int
+}
+
+type ComponentsRegistry {
+	id: Int
+	component_type: Int
+	component_id: Int
+}
+
+type LootMatrix {
+	ActivityRewards: [ActivityRewards!]!
+	ActivityRewards_LootMatrixIndex: [ActivityRewards!]!
+	DestructibleComponent: [DestructibleComponent!]!
+	DestructibleComponent_LootMatrixIndex: [DestructibleComponent!]!
+	LootMatrixIndex: LootMatrixIndex
+	LootTableIndex: LootTable
+	RarityTableIndex: Int
+	percent: Float
+	minToDrop: Int
+	maxToDrop: Int
+	id: Int
+	flagID: Int
+	gate_version: FeatureGating
+	PackageComponent: [PackageComponent!]!
+	PackageComponent_LootMatrixIndex: [PackageComponent!]!
+	SmashableChain: [SmashableChain!]!
+	SmashableChain_lootMatrixID: [SmashableChain!]!
+	SmashableComponent: [SmashableComponent!]!
+	SmashableComponent_LootMatrixIndex: [SmashableComponent!]!
+	VendorComponent: [VendorComponent!]!
+	VendorComponent_LootMatrixIndex: [VendorComponent!]!
+}
+
+type CelebrationParameters {
+	id: Int
+	animation: String
+	backgroundObject: Objects
+	duration: Float
+	subText: String
+	mainText: String
+	iconID: Icons
+	celeLeadIn: Float
+	celeLeadOut: Float
+	cameraPathLOT: Objects
+	pathNodeName: String
+	ambientR: Float
+	ambientG: Float
+	ambientB: Float
+	directionalR: Float
+	directionalG: Float
+	directionalB: Float
+	specularR: Float
+	specularG: Float
+	specularB: Float
+	lightPositionX: Float
+	lightPositionY: Float
+	lightPositionZ: Float
+	blendTime: Float
+	fogColorR: Float
+	fogColorG: Float
+	fogColorB: Float
+	musicCue: String
+	soundGUID: String
+	mixerProgram: String
+}
+
+type RarityTableIndex {
+	RarityTable: [RarityTable!]!
+	RarityTable_RarityTableIndex: [RarityTable!]!
+	RarityTableIndex: Int
+}
+
+type ChoiceBuildComponent {
+	id: Int
+	selections: String
+	imaginationOverride: Int
+}
+
+type ZoneLoadingTips {
+	id: Int
+	zoneid: ZoneTable
+	imagelocation: String
+	localize: Int
+	gate_version: FeatureGating
+	locStatus: Int
+	weight: Int
+	targetVersion: FeatureGating
+	tip1_loc: String
+	tip1_en_US: String
+	tip1_de_DE: String
+	tip1_en_GB: String
+	tip2_loc: String
+	tip2_en_US: String
+	tip2_de_DE: String
+	tip2_en_GB: String
+	title_loc: String
+	title_en_US: String
+	title_de_DE: String
+	title_en_GB: String
+}
+
+type FeatureGating {
+	featureName: String
+	major: Int
+	current: Int
+	minor: Int
+	description: String
+	Activities: [Activities!]!
+	Activities_gate_version: [Activities!]!
+	ActivityText: [ActivityText!]!
+	ActivityText_gate_version: [ActivityText!]!
+	DeletionRestrictions: [DeletionRestrictions!]!
+	DeletionRestrictions_gate_version: [DeletionRestrictions!]!
+	Emotes: [Emotes!]!
+	Emotes_gate_version: [Emotes!]!
+	LootMatrix: [LootMatrix!]!
+	LootMatrix_gate_version: [LootMatrix!]!
+	MissionEmail: [MissionEmail!]!
+	MissionEmail_gate_version: [MissionEmail!]!
+	MissionNPCComponent: [MissionNPCComponent!]!
+	MissionNPCComponent_gate_version: [MissionNPCComponent!]!
+	Missions: [Missions!]!
+	Missions_gate_version: [Missions!]!
+	MissionTasks: [MissionTasks!]!
+	MissionTasks_gate_version: [MissionTasks!]!
+	MissionText: [MissionText!]!
+	MissionText_gate_version: [MissionText!]!
+	Objects: [Objects!]!
+	Objects_gate_version: [Objects!]!
+	PlayerStatistics: [PlayerStatistics!]!
+	PlayerStatistics_gate_version: [PlayerStatistics!]!
+	PropertyTemplate: [PropertyTemplate!]!
+	PropertyTemplate_gate_version: [PropertyTemplate!]!
+	RewardCodes: [RewardCodes!]!
+	RewardCodes_gate_version: [RewardCodes!]!
+	Preconditions: [Preconditions!]!
+	Preconditions_gate_version: [Preconditions!]!
+	SkillBehavior: [SkillBehavior!]!
+	SkillBehavior_gate_version: [SkillBehavior!]!
+	SpeedchatMenu: [SpeedchatMenu!]!
+	SpeedchatMenu_gate_version: [SpeedchatMenu!]!
+	UGBehaviorSounds: [UGBehaviorSounds!]!
+	UGBehaviorSounds_gate_version: [UGBehaviorSounds!]!
+	WhatsCoolItemSpotlight: [WhatsCoolItemSpotlight!]!
+	WhatsCoolItemSpotlight_gate_version: [WhatsCoolItemSpotlight!]!
+	WhatsCoolNewsAndTips: [WhatsCoolNewsAndTips!]!
+	WhatsCoolNewsAndTips_gate_version: [WhatsCoolNewsAndTips!]!
+	ZoneLoadingTips_gate_version: [ZoneLoadingTips!]!
+	ZoneLoadingTips_targetVersion: [ZoneLoadingTips!]!
+}
+
+type ItemSetSkills {
+	SkillSetID: Int
+	SkillID: SkillBehavior
+	SkillCastType: Int
+}
+
+type BehaviorTemplateName {
+	templateID: Int
+	name: String
+	BehaviorTemplate: [BehaviorTemplate!]!
+	BehaviorTemplate_templateID: [BehaviorTemplate!]!
+}
+
+type PackageComponent {
+	id: Int
+	LootMatrixIndex: LootMatrix
+	packageType: Int
+}
+
+type ProximityTypes {
+	id: Int
+	Name: String
+	Radius: Int
+	CollisionGroup: Int
+	PassiveChecks: Int
+	IconID: Icons
+	LoadOnClient: Int
+	LoadOnServer: Int
+}
+
+type CurrencyDenominations {
+	value: Int
+	objectid: Objects
+}
+
+type Missions {
+	MissionPrereqs_mission: [MissionPrereqs!]!
+	MissionPrereqs_prereqMission: [MissionPrereqs!]!
+	MissionTaskMissions: [MissionTaskMissions!]!
+	MissionTaskMissions_mission: [MissionTaskMissions!]!
+	CollectibleComponent: [CollectibleComponent!]!
+	CollectibleComponent_requirement_mission: [CollectibleComponent!]!
+	MissionEmail: [MissionEmail!]!
+	MissionEmail_missionID: [MissionEmail!]!
+	MissionNPCComponent: [MissionNPCComponent!]!
+	MissionNPCComponent_missionID: [MissionNPCComponent!]!
+	id: Int
+	defined_type: String
+	defined_subtype: String
+	UISortOrder: Int
+	offer_objectID: Objects
+	target_objectID: Objects
+	reward_currency: Int
+	LegoScore: Int
+	reward_reputation: Int
+	isChoiceReward: Int
+	reward_item1: Objects
+	reward_item1_count: Int
+	reward_item2: Objects
+	reward_item2_count: Int
+	reward_item3: Objects
+	reward_item3_count: Int
+	reward_item4: Objects
+	reward_item4_count: Int
+	reward_emote: Emotes
+	reward_emote2: Emotes
+	reward_emote3: Emotes
+	reward_emote4: Emotes
+	reward_maximagination: Int
+	reward_maxhealth: Int
+	reward_maxinventory: Int
+	reward_maxmodel: Int
+	reward_maxwidget: Int
+	reward_maxwallet: Int
+	repeatable: Int
+	reward_currency_repeatable: Int
+	reward_item1_repeatable: Objects
+	reward_item1_repeat_count: Int
+	reward_item2_repeatable: Objects
+	reward_item2_repeat_count: Int
+	reward_item3_repeatable: Objects
+	reward_item3_repeat_count: Int
+	reward_item4_repeatable: Objects
+	reward_item4_repeat_count: Int
+	time_limit: Int
+	isMission: Int
+	missionIconID: Icons
+	prereqMissionID: String
+	localize: Int
+	inMOTD: Int
+	cooldownTime: Int
+	isRandom: Int
+	randomPool: String
+	UIPrereqID: Int
+	gate_version: FeatureGating
+	HUDStates: String
+	locStatus: Int
+	reward_bankinventory: Int
+	name_loc: String
+	name_en_US: String
+	name_de_DE: String
+	name_en_GB: String
+	MissionTasks: [MissionTasks!]!
+	MissionTasks_id: [MissionTasks!]!
+	MissionText: [MissionText!]!
+	MissionText_id: [MissionText!]!
+}
+
+type ZoneTable {
+	Activities: [Activities!]!
+	Activities_instanceMapID: [Activities!]!
+	LUPZoneIDs: [LUPZoneIDs!]!
+	LUPZoneIDs_zoneID: [LUPZoneIDs!]!
+	PropertyEntranceComponent: [PropertyEntranceComponent!]!
+	PropertyEntranceComponent_mapID: [PropertyEntranceComponent!]!
+	PropertyTemplate_mapID: [PropertyTemplate!]!
+	PropertyTemplate_vendorMapID: [PropertyTemplate!]!
+	RocketLaunchpadControlComponent_targetZone: [RocketLaunchpadControlComponent!]!
+	RocketLaunchpadControlComponent_defaultZoneID: [RocketLaunchpadControlComponent!]!
+	ZoneLoadingTips: [ZoneLoadingTips!]!
+	ZoneLoadingTips_zoneid: [ZoneLoadingTips!]!
+	ZoneSummary: [ZoneSummary!]!
+	ZoneSummary_zoneID: [ZoneSummary!]!
+	zoneID: Int
+	locStatus: Int
+	zoneName: String
+	scriptID: Int
+	ghostdistance_min: Float
+	ghostdistance: Float
+	population_soft_cap: Int
+	population_hard_cap: Int
+	DisplayDescription: String
+	mapFolder: String
+	smashableMinDistance: Float
+	smashableMaxDistance: Float
+	mixerProgram: String
+	clientPhysicsFramerate: String
+	serverPhysicsFramerate: String
+	zoneControlTemplate: Int
+	widthInChunks: Int
+	heightInChunks: Int
+	petsAllowed: Int
+	localize: Int
+	fZoneWeight: Float
+	thumbnail: String
+	PlayerLoseCoinsOnDeath: Int
+	disableSaveLoc: Int
+	teamRadius: Float
+	gate_version: FeatureGating
+	mountsAllowed: Int
+	DisplayDescription_loc: String
+	DisplayDescription_en_US: String
+	DisplayDescription_de_DE: String
+	DisplayDescription_en_GB: String
+	summary_loc: String
+	summary_en_US: String
+	summary_de_DE: String
+	summary_en_GB: String
+}
+
+type DeletionRestrictions {
+	id: Int
+	restricted: Int
+	ids: String
+	checkType: Int
+	localize: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	failureReason_loc: String
+	failureReason_en_US: String
+	failureReason_de_DE: String
+	failureReason_en_GB: String
+}
+
+type InventoryComponent {
+	id: Int
+	itemid: Objects
+	count: Int
+	equip: Int
+}
+
+type ExhibitComponent {
+	id: Int
+	length: Float
+	width: Float
+	height: Float
+	offsetX: Float
+	offsetY: Float
+	offsetZ: Float
+	fReputationSizeMultiplier: Float
+	fImaginationCost: Float
+}
+
+type ZoneSummary {
+	zoneID: ZoneTable
+	type: Int
+	value: Int
+	_uniqueID: Int
+}
+
+type ItemEggData {
+	id: Int
+	chassie_type_id: Int
+}
+
+type mapAssetType {
+	id: Int
+	label: String
+	pathdir: String
+	typelabel: String
+}
+
+type MinifigComponent {
+	id: Int
+	head: Int
+	chest: Int
+	legs: Int
+	hairstyle: Int
+	haircolor: Int
+	chestdecal: Int
+	headcolor: Int
+	lefthand: Int
+	righthand: Int
+	eyebrowstyle: MinifigDecals_Eyebrows
+	eyesstyle: MinifigDecals_Eyes
+	mouthstyle: MinifigDecals_Mouths
+}
+
+type LUPZoneIDs {
+	zoneID: ZoneTable
+}
+
+type ItemComponent {
+	id: Int
+	equipLocation: String
+	baseValue: Int
+	isKitPiece: Int
+	rarity: Int
+	itemType: mapItemTypes
+	itemInfo: Int
+	inLootTable: Int
+	inVendor: Int
+	isUnique: Int
+	isBOP: Int
+	isBOE: Int
+	reqFlagID: Int
+	reqSpecialtyID: Int
+	reqSpecRank: Int
+	reqAchievementID: Int
+	stackSize: Int
+	color1: Int
+	decal: Int
+	offsetGroupID: Int
+	buildTypes: Int
+	reqPrecondition: String
+	animationFlag: Int
+	equipEffects: Int
+	readyForQA: Int
+	itemRating: Int
+	isTwoHanded: Int
+	minNumRequired: Int
+	delResIndex: Int
+	currencyLOT: Objects
+	altCurrencyCost: Int
+	subItems: String
+	audioEventUse: String
+	noEquipAnimation: Int
+	commendationLOT: Objects
+	commendationCost: Int
+	audioEquipMetaEventSet: String
+	currencyCosts: String
+	ingredientInfo: String
+	locStatus: Int
+	forgeType: Int
+	SellMultiplier: Float
+	ingredientInfo_loc: String
+	ingredientInfo_en_US: String
+	ingredientInfo_de_DE: String
+	ingredientInfo_en_GB: String
+	Objects: [Objects!]!
+	Objects_itemComponent: [Objects!]!
+}
+
+type MovementAIComponent {
+	id: Int
+	MovementType: String
+	WanderChance: Float
+	WanderDelayMin: Float
+	WanderDelayMax: Float
+	WanderSpeed: Float
+	WanderRadius: Float
+	attachedPath: String
+}
+
+type mapRenderEffects {
+	id: Int
+	gameID: Int
+	description: String
+}
+
+type RebuildSections {
+	id: Int
+	rebuildID: Int
+	objectID: Objects
+	offset_x: Float
+	offset_y: Float
+	offset_z: Float
+	fall_angle_x: Float
+	fall_angle_y: Float
+	fall_angle_z: Float
+	fall_height: Float
+	requires_list: String
+	size: Int
+	bPlaced: Int
+}
+
+type PlayerStatistics {
+	statID: Int
+	sortOrder: Int
+	locStatus: Int
+	gate_version: FeatureGating
+	statStr_loc: String
+	statStr_en_US: String
+	statStr_de_DE: String
+	statStr_en_GB: String
+}
+
+type Query {
+	AccessoryDefaultLoc(GroupID: Int, Description: String, Pos_X: Float, Pos_Y: Float, Pos_Z: Float, Rot_X: Float, Rot_Y: Float, Rot_Z: Float): [AccessoryDefaultLoc]
+	ActivityRewards(objectTemplate: Objects, ActivityRewardIndex: Int, activityRating: Int, LootMatrixIndex: LootMatrix, CurrencyIndex: Int, ChallengeRating: Int, description: String): [ActivityRewards]
+	MissionEmail(ID: Int, messageType: Int, notificationGroup: Int, missionID: Missions, attachmentLOT: Objects, localize: Int, locStatus: Int, gate_version: FeatureGating, announceText_loc: String, announceText_en_US: String, announceText_de_DE: String, announceText_en_GB: String, bodyText_loc: String, bodyText_en_US: String, bodyText_de_DE: String, bodyText_en_GB: String, senderName_loc: String, senderName_en_US: String, senderName_de_DE: String, senderName_en_GB: String, subjectText_loc: String, subjectText_en_US: String, subjectText_de_DE: String, subjectText_en_GB: String): [MissionEmail]
+	MissionPrereqs(mission: Missions, andGroup: Int, prereqMission: Missions, prereqMissionState: Int): [MissionPrereqs]
+	BrickColors(id: Int, red: Float, green: Float, blue: Float, alpha: Float, legopaletteid: Int, description: String, validTypes: Int, validCharacters: Int, factoryValid: Int): [BrickColors]
+	WhatsCoolItemSpotlight(id: Int, itemID: Objects, localize: Int, gate_version: FeatureGating, locStatus: Int, description_loc: String, description_en_US: String, description_de_DE: String, description_en_GB: String): [WhatsCoolItemSpotlight]
+	TextLanguage(TextID: Int, LanguageID: Int, Text: String): [TextLanguage]
+	MissionNPCComponent(id: Int, missionID: Missions, offersMission: Int, acceptsMission: Int, gate_version: FeatureGating): [MissionNPCComponent]
+	LUPExhibitModelData(LOT: Objects, minXZ: Float, maxXZ: Float, maxY: Float, description: String, owner: String): [LUPExhibitModelData]
+	BehaviorParameter(behaviorID: Int, parameterID: String, value: Float): [BehaviorParameter]
+	Emotes(id: Int, animationName: String, iconFilename: String, channel: String, command: String, locked: Int, localize: Int, locStatus: Int, gate_version: FeatureGating, outputText_loc: String, outputText_en_US: String, outputText_de_DE: String, outputText_en_GB: String, Missions_reward_emote: [Missions!], Missions_reward_emote2: [Missions!], Missions_reward_emote3: [Missions!], Missions_reward_emote4: [Missions!], SpeedchatMenu: [SpeedchatMenu!], SpeedchatMenu_emoteId: [SpeedchatMenu!]): [Emotes]
+	LootTableIndex(LootTable: [LootTable!], LootTable_LootTableIndex: [LootTable!], LootTableIndex: Int): [LootTableIndex]
+	Blueprints(id: Int, name: String, description: String, accountid: Int, characterid: Int, price: Int, rating: Int, categoryid: Int, lxfpath: String, deleted: Int, created: Int, modified: Int): [Blueprints]
+	mapShaders(id: Int, label: String, gameValue: Int, priority: Int): [mapShaders]
+	DBExclude(table: String, column: String): [DBExclude]
+	MinifigDecals_Torsos(ID: Int, High_path: String, CharacterCreateValid: Int, male: Int, female: Int): [MinifigDecals_Torsos]
+	Objects(MissionTaskObjects: [MissionTaskObjects!], MissionTaskObjects_object: [MissionTaskObjects!], BrickIDTable: [BrickIDTable!], BrickIDTable_NDObjectID: [BrickIDTable!], CelebrationParameters_backgroundObject: [CelebrationParameters!], CelebrationParameters_cameraPathLOT: [CelebrationParameters!], CurrencyDenominations: [CurrencyDenominations!], CurrencyDenominations_objectid: [CurrencyDenominations!], ActivityRewards: [ActivityRewards!], ActivityRewards_objectTemplate: [ActivityRewards!], InventoryComponent: [InventoryComponent!], InventoryComponent_itemid: [InventoryComponent!], JetPackPadComponent_lotBlocker: [JetPackPadComponent!], JetPackPadComponent_lotWarningVolume: [JetPackPadComponent!], LootTable: [LootTable!], LootTable_itemid: [LootTable!], LUPExhibitModelData: [LUPExhibitModelData!], LUPExhibitModelData_LOT: [LUPExhibitModelData!], mapIcon: [mapIcon!], mapIcon_LOT: [mapIcon!], ItemComponent_currencyLOT: [ItemComponent!], ItemComponent_commendationLOT: [ItemComponent!], MissionEmail: [MissionEmail!], MissionEmail_attachmentLOT: [MissionEmail!], Missions_offer_objectID: [Missions!], Missions_target_objectID: [Missions!], Missions_reward_item1: [Missions!], Missions_reward_item2: [Missions!], Missions_reward_item3: [Missions!], Missions_reward_item4: [Missions!], Missions_reward_item1_repeatable: [Missions!], Missions_reward_item2_repeatable: [Missions!], Missions_reward_item3_repeatable: [Missions!], Missions_reward_item4_repeatable: [Missions!], ModularBuildComponent: [ModularBuildComponent!], ModularBuildComponent_createdLOT: [ModularBuildComponent!], NpcIcons_LOT: [NpcIcons!], NpcIcons_compositeLOTMultiMission: [NpcIcons!], NpcIcons_compositeLOTMultiMissionVentor: [NpcIcons!], id: Int, name: String, placeable: Int, type: String, description: String, localize: Int, npcTemplateID: Int, displayName: String, interactionDistance: Float, nametag: Int, _internalNotes: String, locStatus: Int, gate_version: FeatureGating, HQ_valid: Int, description_loc: String, description_en_US: String, description_de_DE: String, description_en_GB: String, name_loc: String, name_en_US: String, name_de_DE: String, name_en_GB: String, itemComponent: ItemComponent, renderComponent: RenderComponent, ObjectSkills: [ObjectSkills!], ObjectSkills_objectTemplate: [ObjectSkills!], RebuildSections: [RebuildSections!], RebuildSections_objectID: [RebuildSections!], RewardCodes: [RewardCodes!], RewardCodes_attachmentLOT: [RewardCodes!], TamingBuildPuzzles_PuzzleModelLot: [TamingBuildPuzzles!], TamingBuildPuzzles_NPCLot: [TamingBuildPuzzles!], WhatsCoolItemSpotlight: [WhatsCoolItemSpotlight!], WhatsCoolItemSpotlight_itemID: [WhatsCoolItemSpotlight!]): [Objects]
+	PetNestComponent(id: Int, ElementalType: Int): [PetNestComponent]
+	brickAttributes(ID: Int, icon_asset: String, display_order: Int, locStatus: Int, name_loc: String, name_en_US: String, name_de_DE: String, name_en_GB: String): [brickAttributes]
+	PropertyEntranceComponent(id: Int, mapID: ZoneTable, propertyName: String, isOnProperty: Int, groupType: String): [PropertyEntranceComponent]
+	Icons(RenderComponent: [RenderComponent!], RenderComponent_IconID: [RenderComponent!], IconID: Int, IconPath: String, IconName: String, CelebrationParameters: [CelebrationParameters!], CelebrationParameters_iconID: [CelebrationParameters!], mapIcon: [mapIcon!], mapIcon_iconID: [mapIcon!], Missions: [Missions!], Missions_missionIconID: [Missions!], MissionTasks_IconID: [MissionTasks!], MissionTasks_largeTaskIconID: [MissionTasks!], MissionText_IconID: [MissionText!], MissionText_turnInIconID: [MissionText!], ProximityTypes: [ProximityTypes!], ProximityTypes_IconID: [ProximityTypes!], Preconditions: [Preconditions!], Preconditions_iconID: [Preconditions!], SkillBehavior: [SkillBehavior!], SkillBehavior_skillIcon: [SkillBehavior!], WhatsCoolNewsAndTips: [WhatsCoolNewsAndTips!], WhatsCoolNewsAndTips_iconID: [WhatsCoolNewsAndTips!]): [Icons]
+	ItemSets(setID: Int, locStatus: Int, itemIDs: String, kitType: Int, kitRank: Int, kitImage: Int, skillSetWith2: Int, skillSetWith3: Int, skillSetWith4: Int, skillSetWith5: Int, skillSetWith6: Int, localize: Int, gate_version: String, kitID: Int, priority: Float, kitName_loc: String, kitName_en_US: String, kitName_de_DE: String, kitName_en_GB: String): [ItemSets]
+	ObjectBehaviorXREF(LOT: Int, behaviorID1: Int, behaviorID2: Int, behaviorID3: Int, behaviorID4: Int, behaviorID5: Int, type: Int): [ObjectBehaviorXREF]
+	RenderComponentWrapper(id: Int, defaultWrapperAsset: String): [RenderComponentWrapper]
+	ControlSchemes(control_scheme: Int, scheme_name: String, rotation_speed: Float, walk_forward_speed: Float, walk_backward_speed: Float, walk_strafe_speed: Float, walk_strafe_forward_speed: Float, walk_strafe_backward_speed: Float, run_backward_speed: Float, run_strafe_speed: Float, run_strafe_forward_speed: Float, run_strafe_backward_speed: Float, keyboard_zoom_sensitivity: Float, keyboard_pitch_sensitivity: Float, keyboard_yaw_sensitivity: Float, mouse_zoom_wheel_sensitivity: Float, x_mouse_move_sensitivity_modifier: Float, y_mouse_move_sensitivity_modifier: Float, freecam_speed_modifier: Float, freecam_slow_speed_multiplier: Float, freecam_fast_speed_multiplier: Float, freecam_mouse_modifier: Float, gamepad_pitch_rot_sensitivity: Float, gamepad_yaw_rot_sensitivity: Float, gamepad_trigger_sensitivity: Float, PossessableComponent: [PossessableComponent!], PossessableComponent_controlSchemeID: [PossessableComponent!]): [ControlSchemes]
+	DevModelBehaviors(ModelID: Int, BehaviorID: Int): [DevModelBehaviors]
+	BaseCombatAIComponent(id: Int, behaviorType: Int, combatRoundLength: Float, combatRole: Int, minRoundLength: Float, maxRoundLength: Float, tetherSpeed: Float, pursuitSpeed: Float, combatStartDelay: Float, softTetherRadius: Float, hardTetherRadius: Float, spawnTimer: Float, tetherEffectID: Int, ignoreMediator: Int, aggroRadius: Float, ignoreStatReset: Int, ignoreParent: Int): [BaseCombatAIComponent]
+	BrickIDTable(NDObjectID: Objects, LEGOBrickID: Int): [BrickIDTable]
+	LUPExhibitComponent(id: Int, minXZ: Float, maxXZ: Float, maxY: Float, offsetX: Float, offsetY: Float, offsetZ: Float): [LUPExhibitComponent]
+	MinifigDecals_Legs(ID: Int, High_path: String): [MinifigDecals_Legs]
+	DestructibleComponent(id: Int, faction: Factions, factionList: String, life: Int, imagination: Int, LootMatrixIndex: LootMatrix, CurrencyIndex: Int, level: Int, armor: Float, death_behavior: Int, isnpc: Int, attack_priority: Int, isSmashable: Int, difficultyLevel: Int): [DestructibleComponent]
+	SceneTable(sceneID: Int, sceneName: String): [SceneTable]
+	RenderComponentFlash(id: Int, interactive: Int, animated: Int, nodeName: String, flashPath: String, elementName: String, _uid: Int): [RenderComponentFlash]
+	ItemFoodData(id: Int, element_1: Int, element_1_amount: Int, element_2: Int, element_2_amount: Int, element_3: Int, element_3_amount: Int, element_4: Int, element_4_amount: Int): [ItemFoodData]
+	SpeedchatMenu(id: Int, parentId: Int, emoteId: Emotes, imageName: String, localize: Int, locStatus: Int, gate_version: FeatureGating, menuText_loc: String, menuText_en_US: String, menuText_de_DE: String, menuText_en_GB: String): [SpeedchatMenu]
+	JetPackPadComponent(id: Int, xDistance: Float, yDistance: Float, warnDistance: Float, lotBlocker: Objects, lotWarningVolume: Objects): [JetPackPadComponent]
+	mapIcon(LOT: Objects, iconID: Icons, iconState: Int): [mapIcon]
+	dtproperties(id: Int, objectid: Int, property: String, value: String, uvalue: String, lvalue: String, version: Int): [dtproperties]
+	LootTable(LootMatrix: [LootMatrix!], LootMatrix_LootTableIndex: [LootMatrix!], itemid: Objects, LootTableIndex: LootTableIndex, id: Int, MissionDrop: Int, sortPriority: Int): [LootTable]
+	mapItemTypes(id: Int, description: String, equipLocation: String, ItemComponent: [ItemComponent!], ItemComponent_itemType: [ItemComponent!]): [mapItemTypes]
+	MissionText(id: Missions, story_icon: String, missionIcon: String, offerNPCIcon: String, IconID: Icons, state_1_anim: String, state_2_anim: String, state_3_anim: String, state_4_anim: String, state_3_turnin_anim: String, state_4_turnin_anim: String, onclick_anim: String, CinematicAccepted: String, CinematicAcceptedLeadin: Float, CinematicCompleted: String, CinematicCompletedLeadin: Float, CinematicRepeatable: String, CinematicRepeatableLeadin: Float, CinematicRepeatableCompleted: String, CinematicRepeatableCompletedLeadin: Float, AudioEventGUID_Interact: String, AudioEventGUID_OfferAccept: String, AudioEventGUID_OfferDeny: String, AudioEventGUID_Completed: String, AudioEventGUID_TurnIn: String, AudioEventGUID_Failed: String, AudioEventGUID_Progress: String, AudioMusicCue_OfferAccept: String, AudioMusicCue_TurnIn: String, turnInIconID: Icons, localize: Int, locStatus: Int, gate_version: FeatureGating, accept_chat_bubble_loc: String, accept_chat_bubble_en_US: String, accept_chat_bubble_de_DE: String, accept_chat_bubble_en_GB: String, chat_state_1_loc: String, chat_state_1_en_US: String, chat_state_1_de_DE: String, chat_state_1_en_GB: String, chat_state_2_loc: String, chat_state_2_en_US: String, chat_state_2_de_DE: String, chat_state_2_en_GB: String, chat_state_3_turnin_loc: String, chat_state_3_turnin_en_US: String, chat_state_3_turnin_de_DE: String, chat_state_3_turnin_en_GB: String, completion_succeed_tip_loc: String, completion_succeed_tip_en_US: String, completion_succeed_tip_de_DE: String, completion_succeed_tip_en_GB: String, in_progress_loc: String, in_progress_en_US: String, in_progress_de_DE: String, in_progress_en_GB: String, offer_loc: String, offer_en_US: String, offer_de_DE: String, offer_en_GB: String, ready_to_complete_loc: String, ready_to_complete_en_US: String, ready_to_complete_de_DE: String, ready_to_complete_en_GB: String, description_loc: String, description_en_US: String, description_de_DE: String, description_en_GB: String, chat_state_3_loc: String, chat_state_3_en_US: String, chat_state_3_de_DE: String, chat_state_3_en_GB: String, chat_state_4_loc: String, chat_state_4_en_US: String, chat_state_4_de_DE: String, chat_state_4_en_GB: String, chat_state_4_turnin_loc: String, chat_state_4_turnin_en_US: String, chat_state_4_turnin_de_DE: String, chat_state_4_turnin_en_GB: String, offer_repeatable_loc: String, offer_repeatable_en_US: String, offer_repeatable_de_DE: String, offer_repeatable_en_GB: String): [MissionText]
+	PhysicsComponent(id: Int, static: Float, physics_asset: String, jump: Float, doublejump: Float, speed: Float, rotSpeed: Float, playerHeight: Float, playerRadius: Float, pcShapeType: Int, collisionGroup: Int, airSpeed: Float, boundaryAsset: String, jumpAirSpeed: Float, friction: Float, gravityVolumeAsset: String): [PhysicsComponent]
+	ReputationRewards(repLevel: Int, sublevel: Int, reputation: Float): [ReputationRewards]
+	RarityTable(id: Int, randmax: Float, rarity: Int, RarityTableIndex: RarityTableIndex, SmashableChain: [SmashableChain!], SmashableChain_rarityTableIndex: [SmashableChain!]): [RarityTable]
+	MinifigDecals_Eyebrows(ID: Int, High_path: String, Low_path: String, CharacterCreateValid: Int, male: Int, female: Int, MinifigComponent: [MinifigComponent!], MinifigComponent_eyebrowstyle: [MinifigComponent!]): [MinifigDecals_Eyebrows]
+	CollectibleComponent(id: Int, requirement_mission: Missions): [CollectibleComponent]
+	RocketLaunchpadControlComponent(id: Int, targetZone: ZoneTable, defaultZoneID: ZoneTable, targetScene: String, gmLevel: Int, playerAnimation: String, rocketAnimation: String, launchMusic: String, useLaunchPrecondition: Int, useAltLandingPrecondition: Int, launchPrecondition: String, altLandingPrecondition: String, altLandingSpawnPointName: String): [RocketLaunchpadControlComponent]
+	PlayerFlags(id: Int, SessionOnly: Int, OnlySetByServer: Int, SessionZoneOnly: Int): [PlayerFlags]
+	SmashableChainIndex(id: Int, targetGroup: String, description: String, continuous: Int): [SmashableChainIndex]
+	PetAbilities(id: Int, AbilityName: String, ImaginationCost: Int, locStatus: Int, DisplayName_loc: String, DisplayName_en_US: String, DisplayName_de_DE: String, DisplayName_en_GB: String): [PetAbilities]
+	mapAnimationPriorities(id: Int, name: String, priority: Float): [mapAnimationPriorities]
+	RewardCodes(id: Int, code: String, attachmentLOT: Objects, locStatus: Int, gate_version: FeatureGating, bodyText_loc: String, bodyText_en_US: String, bodyText_de_DE: String, bodyText_en_GB: String, subjectText_loc: String, subjectText_en_US: String, subjectText_de_DE: String, subjectText_en_GB: String): [RewardCodes]
+	RailActivatorComponent(id: Int, startAnim: String, loopAnim: String, stopAnim: String, startSound: String, loopSound: String, stopSound: String, effectIDs: String, preconditions: String, playerCollision: Int, cameraLocked: Int, StartEffectID: String, StopEffectID: String, DamageImmune: Int, NoAggro: Int, ShowNameBillboard: Int): [RailActivatorComponent]
+	PropertyTemplate(id: Int, mapID: ZoneTable, vendorMapID: ZoneTable, spawnName: String, type: Int, sizecode: Int, minimumPrice: Int, rentDuration: Int, path: String, cloneLimit: Int, durationType: Int, achievementRequired: Int, zoneX: Float, zoneY: Float, zoneZ: Float, maxBuildHeight: Float, localize: Int, reputationPerMinute: Int, locStatus: Int, gate_version: FeatureGating, description_loc: String, description_en_US: String, description_de_DE: String, description_en_GB: String, name_loc: String, name_en_US: String, name_de_DE: String, name_en_GB: String): [PropertyTemplate]
+	AICombatRoles(id: Int, preferredRole: Int, specifiedMinRangeNOUSE: Float, specifiedMaxRangeNOUSE: Float, specificMinRange: Float, specificMaxRange: Float): [AICombatRoles]
+	MinifigDecals_Eyes(ID: Int, High_path: String, Low_path: String, CharacterCreateValid: Int, male: Int, female: Int, MinifigComponent: [MinifigComponent!], MinifigComponent_eyesstyle: [MinifigComponent!]): [MinifigDecals_Eyes]
+	MinifigDecals_Mouths(ID: Int, High_path: String, Low_path: String, CharacterCreateValid: Int, male: Int, female: Int, MinifigComponent: [MinifigComponent!], MinifigComponent_mouthstyle: [MinifigComponent!]): [MinifigDecals_Mouths]
+	mapTextureResource(id: Int, texturepath: String, SurfaceType: Int): [mapTextureResource]
+	Camera(camera_name: String, pitch_angle_tolerance: Float, starting_zoom: Float, zoom_return_modifier: Float, pitch_return_modifier: Float, tether_out_return_modifier: Float, tether_in_return_multiplier: Float, verticle_movement_dampening_modifier: Float, return_from_incline_modifier: Float, horizontal_return_modifier: Float, yaw_behavior_speed_multiplier: Float, camera_collision_padding: Float, glide_speed: Float, fade_player_min_range: Float, min_movement_delta_tolerance: Float, min_glide_distance_tolerance: Float, look_forward_offset: Float, look_up_offset: Float, minimum_vertical_dampening_distance: Float, maximum_vertical_dampening_distance: Float, minimum_ignore_jump_distance: Float, maximum_ignore_jump_distance: Float, maximum_auto_glide_angle: Float, minimum_tether_glide_distance: Float, yaw_sign_correction: Float, set_1_look_forward_offset: Float, set_1_look_up_offset: Float, set_2_look_forward_offset: Float, set_2_look_up_offset: Float, set_0_speed_influence_on_dir: Float, set_1_speed_influence_on_dir: Float, set_2_speed_influence_on_dir: Float, set_0_angular_relaxation: Float, set_1_angular_relaxation: Float, set_2_angular_relaxation: Float, set_0_position_up_offset: Float, set_1_position_up_offset: Float, set_2_position_up_offset: Float, set_0_position_forward_offset: Float, set_1_position_forward_offset: Float, set_2_position_forward_offset: Float, set_0_FOV: Float, set_1_FOV: Float, set_2_FOV: Float, set_0_max_yaw_angle: Float, set_1_max_yaw_angle: Float, set_2_max_yaw_angle: Float, set_1_fade_in_camera_set_change: Int, set_1_fade_out_camera_set_change: Int, set_2_fade_in_camera_set_change: Int, set_2_fade_out_camera_set_change: Int, input_movement_scalar: Float, input_rotation_scalar: Float, input_zoom_scalar: Float, minimum_pitch_desired: Float, maximum_pitch_desired: Float, minimum_zoom: Float, maximum_zoom: Float, horizontal_rotate_tolerance: Float, horizontal_rotate_modifier: Float): [Camera]
+	ModuleComponent(id: Int, partCode: Int, buildType: Int, xml: String, primarySoundGUID: String, assembledEffectID: Int): [ModuleComponent]
+	ActivityText(activityID: Activities, type: String, localize: Int, locStatus: Int, gate_version: FeatureGating, broadcast_subjectText_loc: String, broadcast_subjectText_en_US: String, broadcast_subjectText_de_DE: String, broadcast_subjectText_en_GB: String, broadcast_text_loc: String, broadcast_text_en_US: String, broadcast_text_de_DE: String, broadcast_text_en_GB: String, mail_subjectText_loc: String, mail_subjectText_en_US: String, mail_subjectText_de_DE: String, mail_subjectText_en_GB: String, mail_text_loc: String, mail_text_en_US: String, mail_text_de_DE: String, mail_text_en_GB: String, hint10_text_loc: String, hint10_text_en_US: String, hint10_text_de_DE: String, hint10_text_en_GB: String, hint11_text_loc: String, hint11_text_en_US: String, hint11_text_de_DE: String, hint11_text_en_GB: String, hint1_text_loc: String, hint1_text_en_US: String, hint1_text_de_DE: String, hint1_text_en_GB: String, hint2_text_loc: String, hint2_text_en_US: String, hint2_text_de_DE: String, hint2_text_en_GB: String, hint3_text_loc: String, hint3_text_en_US: String, hint3_text_de_DE: String, hint3_text_en_GB: String, hint4_text_loc: String, hint4_text_en_US: String, hint4_text_de_DE: String, hint4_text_en_GB: String, hint5_text_loc: String, hint5_text_en_US: String, hint5_text_de_DE: String, hint5_text_en_GB: String, hint6_text_loc: String, hint6_text_en_US: String, hint6_text_de_DE: String, hint6_text_en_GB: String, hint7_text_loc: String, hint7_text_en_US: String, hint7_text_de_DE: String, hint7_text_en_GB: String, hint8_text_loc: String, hint8_text_en_US: String, hint8_text_de_DE: String, hint8_text_en_GB: String, hint9_text_loc: String, hint9_text_en_US: String, hint9_text_de_DE: String, hint9_text_en_GB: String): [ActivityText]
+	Preconditions(id: Int, type: Int, targetLOT: String, targetGroup: String, targetCount: Int, iconID: Icons, localize: Int, validContexts: Int, locStatus: Int, gate_version: FeatureGating, FailureReason_loc: String, FailureReason_en_US: String, FailureReason_de_DE: String, FailureReason_en_GB: String): [Preconditions]
+	ScriptComponent(id: Int, script_name: String, client_script_name: String): [ScriptComponent]
+	UGBehaviorSounds(id: Int, guid: String, localize: Int, locStatus: Int, gate_version: FeatureGating, name_loc: String, name_en_US: String, name_de_DE: String, name_en_GB: String): [UGBehaviorSounds]
+	WhatsCoolNewsAndTips(id: Int, iconID: Icons, type: Int, localize: Int, gate_version: FeatureGating, locStatus: Int, storyTitle_loc: String, storyTitle_en_US: String, storyTitle_de_DE: String, storyTitle_en_GB: String, text_loc: String, text_en_US: String, text_de_DE: String, text_en_GB: String): [WhatsCoolNewsAndTips]
+	ModelBehavior(id: Int, definitionXMLfilename: String): [ModelBehavior]
+	AnimationIndex(animationGroupID: Int, description: String, groupType: String): [AnimationIndex]
+	RacingModuleComponent(id: Int, topSpeed: Float, acceleration: Float, handling: Float, stability: Float, imagination: Float): [RacingModuleComponent]
+	BuffParameters(BuffID: BuffDefinitions, ParameterName: String, NumberValue: Float, StringValue: String, EffectID: Int): [BuffParameters]
+	RenderComponent(id: Int, render_asset: String, icon_asset: String, IconID: Icons, shader_id: Int, effect1: Int, effect2: Int, effect3: Int, effect4: Int, effect5: Int, effect6: Int, animationGroupIDs: String, fade: Int, usedropshadow: Int, preloadAnimations: Int, fadeInTime: Float, maxShadowDistance: Float, ignoreCameraCollision: Int, renderComponentLOD1: Int, renderComponentLOD2: Int, gradualSnap: Int, animationFlag: Int, AudioMetaEventSet: String, billboardHeight: Float, chatBubbleOffset: Float, staticBillboard: Int, LXFMLFolder: String, attachIndicatorsToNode: Int, Objects: [Objects!], Objects_renderComponent: [Objects!]): [RenderComponent]
+	RenderIconAssets(id: Int, icon_asset: String, blank_column: String): [RenderIconAssets]
+	FlairTable(id: Int, asset: String): [FlairTable]
+	MotionFX(id: Int, typeID: Int, slamVelocity: Float, addVelocity: Float, duration: Float, destGroupName: String, startScale: Float, endScale: Float, velocity: Float, distance: Float): [MotionFX]
+	TrailEffects(trailID: Int, textureName: String, blendmode: Int, cardlifetime: Float, colorlifetime: Float, minTailFade: Float, tailFade: Float, max_particles: Int, birthDelay: Float, deathDelay: Float, bone1: String, bone2: String, texLength: Float, texWidth: Float, startColorR: Float, startColorG: Float, startColorB: Float, startColorA: Float, middleColorR: Float, middleColorG: Float, middleColorB: Float, middleColorA: Float, endColorR: Float, endColorG: Float, endColorB: Float, endColorA: Float): [TrailEffects]
+	map_BlueprintCategory(id: Int, description: String, enabled: Int): [map_BlueprintCategory]
+	EventGating(eventName: String, date_start: Int, date_end: Int): [EventGating]
+	SurfaceType(SurfaceType: Int, FootstepNDAudioMetaEventSetName: String): [SurfaceType]
+	ModularBuildComponent(id: Int, buildType: Int, xml: String, createdLOT: Objects, createdPhysicsID: Int, AudioEventGUID_Snap: String, AudioEventGUID_Complete: String, AudioEventGUID_Present: String): [ModularBuildComponent]
+	ObjectSkills(objectTemplate: Objects, skillID: SkillBehavior, castOnType: Int, AICombatWeight: Int): [ObjectSkills]
+	VendorComponent(id: Int, buyScalar: Float, sellScalar: Float, refreshTimeSeconds: Float, LootMatrixIndex: LootMatrix): [VendorComponent]
+	MissionTasks(MissionTaskObjects: [MissionTaskObjects!], MissionTaskObjects_missionTask: [MissionTaskObjects!], MissionTaskMissions: [MissionTaskMissions!], MissionTaskMissions_missionTask: [MissionTaskMissions!], id: Missions, locStatus: Int, taskType: Int, target: Int, targetGroup: String, targetValue: Int, taskParam1: String, largeTaskIcon: String, IconID: Icons, uid: Int, largeTaskIconID: Icons, localize: Int, gate_version: FeatureGating, description_loc: String, description_en_US: String, description_de_DE: String, description_en_GB: String): [MissionTasks]
+	SubscriptionPricing(id: Int, countryCode: String, monthlyFeeGold: String, monthlyFeeSilver: String, monthlyFeeBronze: String, monetarySymbol: Int, symbolIsAppended: Int): [SubscriptionPricing]
+	ProximityMonitorComponent(id: Int, Proximities: String, LoadOnClient: Int, LoadOnServer: Int): [ProximityMonitorComponent]
+	RebuildComponent(id: Int, reset_time: Float, complete_time: Float, take_imagination: Int, interruptible: Int, self_activator: Int, custom_modules: String, activityID: Activities, post_imagination_cost: Int, time_before_smash: Float): [RebuildComponent]
+	BuffDefinitions(ID: Int, Priority: Float, UIIcon: String, BuffParameters: [BuffParameters!], BuffParameters_BuffID: [BuffParameters!]): [BuffDefinitions]
+	sysdiagrams(name: String, principal_id: Int, diagram_id: Int, version: Int, definition: String): [sysdiagrams]
+	LevelProgressionLookup(id: Int, requiredUScore: Int, BehaviorEffect: String): [LevelProgressionLookup]
+	TextDescription(TextID: Int, TestDescription: String): [TextDescription]
+	VehiclePhysics(id: Int, hkxFilename: String, fGravityScale: Float, fMass: Float, fChassisFriction: Float, fMaxSpeed: Float, fEngineTorque: Float, fBrakeFrontTorque: Float, fBrakeRearTorque: Float, fBrakeMinInputToBlock: Float, fBrakeMinTimeToBlock: Float, fSteeringMaxAngle: Float, fSteeringSpeedLimitForMaxAngle: Float, fSteeringMinAngle: Float, fFwdBias: Float, fFrontTireFriction: Float, fRearTireFriction: Float, fFrontTireFrictionSlide: Float, fRearTireFrictionSlide: Float, fFrontTireSlipAngle: Float, fRearTireSlipAngle: Float, fWheelWidth: Float, fWheelRadius: Float, fWheelMass: Float, fReorientPitchStrength: Float, fReorientRollStrength: Float, fSuspensionLength: Float, fSuspensionStrength: Float, fSuspensionDampingCompression: Float, fSuspensionDampingRelaxation: Float, iChassisCollisionGroup: Int, fNormalSpinDamping: Float, fCollisionSpinDamping: Float, fCollisionThreshold: Float, fTorqueRollFactor: Float, fTorquePitchFactor: Float, fTorqueYawFactor: Float, fInertiaRoll: Float, fInertiaPitch: Float, fInertiaYaw: Float, fExtraTorqueFactor: Float, fCenterOfMassFwd: Float, fCenterOfMassUp: Float, fCenterOfMassRight: Float, fWheelHardpointFrontFwd: Float, fWheelHardpointFrontUp: Float, fWheelHardpointFrontRight: Float, fWheelHardpointRearFwd: Float, fWheelHardpointRearUp: Float, fWheelHardpointRearRight: Float, fInputTurnSpeed: Float, fInputDeadTurnBackSpeed: Float, fInputAccelSpeed: Float, fInputDeadAccelDownSpeed: Float, fInputDecelSpeed: Float, fInputDeadDecelDownSpeed: Float, fInputSlopeChangePointX: Float, fInputInitialSlope: Float, fInputDeadZone: Float, fAeroAirDensity: Float, fAeroFrontalArea: Float, fAeroDragCoefficient: Float, fAeroLiftCoefficient: Float, fAeroExtraGravity: Float, fBoostTopSpeed: Float, fBoostCostPerSecond: Float, fBoostAccelerateChange: Float, fBoostDampingChange: Float, fPowerslideNeutralAngle: Float, fPowerslideTorqueStrength: Float, iPowerslideNumTorqueApplications: Int, fImaginationTankSize: Float, fSkillCost: Float, fWreckSpeedBase: Float, fWreckSpeedPercent: Float, fWreckMinAngle: Float, AudioEventEngine: String, AudioEventSkid: String, AudioEventLightHit: String, AudioSpeedThresholdLightHit: Float, AudioTimeoutLightHit: Float, AudioEventHeavyHit: String, AudioSpeedThresholdHeavyHit: Float, AudioTimeoutHeavyHit: Float, AudioEventStart: String, AudioEventTreadConcrete: String, AudioEventTreadSand: String, AudioEventTreadWood: String, AudioEventTreadDirt: String, AudioEventTreadPlastic: String, AudioEventTreadGrass: String, AudioEventTreadGravel: String, AudioEventTreadMud: String, AudioEventTreadWater: String, AudioEventTreadSnow: String, AudioEventTreadIce: String, AudioEventTreadMetal: String, AudioEventTreadLeaves: String, AudioEventLightLand: String, AudioAirtimeForLightLand: Float, AudioEventHeavyLand: String, AudioAirtimeForHeavyLand: Float, bWheelsVisible: Int): [VehiclePhysics]
+	PetComponent(id: Int, minTameUpdateTime: Float, maxTameUpdateTime: Float, percentTameChance: Float, tamability: Float, elementType: Int, walkSpeed: Float, runSpeed: Float, sprintSpeed: Float, idleTimeMin: Float, idleTimeMax: Float, petForm: Int, imaginationDrainRate: Float, AudioMetaEventSet: String, buffIDs: String): [PetComponent]
+	ObjectBehaviors(BehaviorID: Int, xmldata: String): [ObjectBehaviors]
+	PossessableComponent(id: Int, controlSchemeID: ControlSchemes, minifigAttachPoint: String, minifigAttachAnimation: String, minifigDetachAnimation: String, mountAttachAnimation: String, mountDetachAnimation: String, attachOffsetFwd: Float, attachOffsetRight: Float, possessionType: Int, wantBillboard: Int, billboardOffsetUp: Float, depossessOnHit: Int, hitStunTime: Float, skillSet: Int): [PossessableComponent]
+	BehaviorEffect(effectID: Int, effectType: String, effectName: String, trailID: Int, pcreateDuration: Float, animationName: String, attachToObject: Int, boneName: String, useSecondary: Int, cameraEffectType: Int, cameraDuration: Float, cameraFrequency: Float, cameraXAmp: Float, cameraYAmp: Float, cameraZAmp: Float, cameraRotFrequency: Float, cameraRoll: Float, cameraPitch: Float, cameraYaw: Float, AudioEventGUID: String, renderEffectType: Int, renderEffectTime: Float, renderStartVal: Float, renderEndVal: Float, renderDelayVal: Float, renderValue1: Float, renderValue2: Float, renderValue3: Float, renderRGBA: String, renderShaderVal: Int, motionID: Int, meshID: Int, meshDuration: Float, meshLockedNode: String): [BehaviorEffect]
+	LootMatrixIndex(LootMatrixIndex: Int, inNpcEditor: Int, LootMatrix: [LootMatrix!], LootMatrix_LootMatrixIndex: [LootMatrix!]): [LootMatrixIndex]
+	VehicleStatMap(id: Int, ModuleStat: String, HavokStat: String, HavokChangePerModuleStat: Float): [VehicleStatMap]
+	MovingPlatforms(id: Int, platformIsSimpleMover: Int, platformMoveX: Float, platformMoveY: Float, platformMoveZ: Float, platformMoveTime: Float, platformStartAtEnd: Int, description: String): [MovingPlatforms]
+	MissionTaskMissions(missionTask: MissionTasks, mission: Missions): [MissionTaskMissions]
+	Factions(DestructibleComponent: [DestructibleComponent!], DestructibleComponent_faction: [DestructibleComponent!], faction: Int, factionList: String, factionListFriendly: Int, friendList: String, enemyList: String): [Factions]
+	SkillBehavior(ItemSetSkills: [ItemSetSkills!], ItemSetSkills_SkillID: [ItemSetSkills!], ObjectSkills: [ObjectSkills!], ObjectSkills_skillID: [ObjectSkills!], skillID: Int, locStatus: Int, behaviorID: Int, imaginationcost: Int, cooldowngroup: Int, cooldown: Float, inNpcEditor: Int, skillIcon: Icons, oomSkillID: String, oomBehaviorEffectID: Int, castTypeDesc: Int, imBonusUI: Int, lifeBonusUI: Int, armorBonusUI: Int, damageUI: Int, hideIcon: Int, localize: Int, gate_version: FeatureGating, cancelType: Int, descriptionUI_loc: String, descriptionUI_en_US: String, descriptionUI_de_DE: String, descriptionUI_en_GB: String, name_loc: String, name_en_US: String, name_de_DE: String, name_en_GB: String): [SkillBehavior]
+	Activities(ActivityID: Int, locStatus: Int, instanceMapID: ZoneTable, minTeams: Int, maxTeams: Int, minTeamSize: Int, maxTeamSize: Int, waitTime: Int, startDelay: Int, requiresUniqueData: Int, leaderboardType: Int, localize: Int, optionalCostLOT: Int, optionalCostCount: Int, showUIRewards: Int, CommunityActivityFlagID: Int, gate_version: FeatureGating, noTeamLootOnDeath: Int, optionalPercentage: Float, ActivityName_loc: String, ActivityName_en_US: String, ActivityName_de_DE: String, ActivityName_en_GB: String, ActivityText: [ActivityText!], ActivityText_activityID: [ActivityText!], RebuildComponent: [RebuildComponent!], RebuildComponent_activityID: [RebuildComponent!]): [Activities]
+	SmashableComponent(id: Int, LootMatrixIndex: LootMatrix): [SmashableComponent]
+	TamingBuildPuzzles(id: Int, PuzzleModelLot: Objects, NPCLot: Objects, ValidPiecesLXF: String, InvalidPiecesLXF: String, Difficulty: Int, Timelimit: Int, NumValidPieces: Int, TotalNumPieces: Int, ModelName: String, FullModelLXF: String, Duration: Float, imagCostPerBuild: Int): [TamingBuildPuzzles]
+	Animations(animationGroupID: Int, animation_type: String, animation_name: String, chance_to_play: Float, min_loops: Int, max_loops: Int, animation_length: Float, hideEquip: Int, ignoreUpperBody: Int, restartable: Int, face_animation_name: String, priority: Float, blendTime: Float): [Animations]
+	NpcIcons(id: Int, color: Int, offset: Float, LOT: Objects, Texture: String, isClickable: Int, scale: Float, rotateToFace: Int, compositeHorizOffset: Float, compositeVertOffset: Float, compositeScale: Float, compositeConnectionNode: String, compositeLOTMultiMission: Objects, compositeLOTMultiMissionVentor: Objects, compositeIconTexture: String): [NpcIcons]
+	SmashableElements(elementID: Int, dropWeight: Int): [SmashableElements]
+	Rewards(id: Int, LevelID: Int, MissionID: Int, RewardType: Int, value: Int, count: Int): [Rewards]
+	BehaviorTemplate(behaviorID: Int, templateID: BehaviorTemplateName, effectID: Int, effectHandle: String): [BehaviorTemplate]
+	SmashableChain(chainIndex: Int, chainLevel: Int, lootMatrixID: LootMatrix, rarityTableIndex: RarityTable, currencyIndex: Int, currencyLevel: Int, smashCount: Int, timeLimit: Int, chainStepID: Int): [SmashableChain]
+	Release_Version(ReleaseVersion: String, ReleaseDate: Int): [Release_Version]
+	WorldConfig(WorldConfigID: Int, pegravityvalue: Float, pebroadphaseworldsize: Float, pegameobjscalefactor: Float, character_rotation_speed: Float, character_walk_forward_speed: Float, character_walk_backward_speed: Float, character_walk_strafe_speed: Float, character_walk_strafe_forward_speed: Float, character_walk_strafe_backward_speed: Float, character_run_backward_speed: Float, character_run_strafe_speed: Float, character_run_strafe_forward_speed: Float, character_run_strafe_backward_speed: Float, global_cooldown: Float, characterGroundedTime: Float, characterGroundedSpeed: Float, globalImmunityTime: Float, character_max_slope: Float, defaultrespawntime: Float, mission_tooltip_timeout: Float, vendor_buy_multiplier: Float, pet_follow_radius: Float, character_eye_height: Float, flight_vertical_velocity: Float, flight_airspeed: Float, flight_fuel_ratio: Float, flight_max_airspeed: Float, fReputationPerVote: Float, nPropertyCloneLimit: Int, defaultHomespaceTemplate: Int, coins_lost_on_death_percent: Float, coins_lost_on_death_min: Int, coins_lost_on_death_max: Int, character_votes_per_day: Int, property_moderation_request_approval_cost: Int, property_moderation_request_review_cost: Int, propertyModRequestsAllowedSpike: Int, propertyModRequestsAllowedInterval: Int, propertyModRequestsAllowedTotal: Int, propertyModRequestsSpikeDuration: Int, propertyModRequestsIntervalDuration: Int, modelModerateOnCreate: Int, defaultPropertyMaxHeight: Float, reputationPerVoteCast: Float, reputationPerVoteReceived: Float, showcaseTopModelConsiderationBattles: Int, reputationPerBattlePromotion: Float, coins_lost_on_death_min_timeout: Float, coins_lost_on_death_max_timeout: Float, mail_base_fee: Int, mail_percent_attachment_fee: Float, propertyReputationDelay: Int, LevelCap: Int, LevelUpBehaviorEffect: String, CharacterVersion: Int, LevelCapCurrencyConversion: Int): [WorldConfig]
+	MissionTaskObjects(missionTask: MissionTasks, object: Objects): [MissionTaskObjects]
+	LanguageType(LanguageID: Int, LanguageDescription: String): [LanguageType]
+	CurrencyTable(currencyIndex: Int, npcminlevel: Int, minvalue: Int, maxvalue: Int, id: Int): [CurrencyTable]
+	ComponentsRegistry(id: Int, component_type: Int, component_id: Int): [ComponentsRegistry]
+	LootMatrix(ActivityRewards: [ActivityRewards!], ActivityRewards_LootMatrixIndex: [ActivityRewards!], DestructibleComponent: [DestructibleComponent!], DestructibleComponent_LootMatrixIndex: [DestructibleComponent!], LootMatrixIndex: LootMatrixIndex, LootTableIndex: LootTable, RarityTableIndex: Int, percent: Float, minToDrop: Int, maxToDrop: Int, id: Int, flagID: Int, gate_version: FeatureGating, PackageComponent: [PackageComponent!], PackageComponent_LootMatrixIndex: [PackageComponent!], SmashableChain: [SmashableChain!], SmashableChain_lootMatrixID: [SmashableChain!], SmashableComponent: [SmashableComponent!], SmashableComponent_LootMatrixIndex: [SmashableComponent!], VendorComponent: [VendorComponent!], VendorComponent_LootMatrixIndex: [VendorComponent!]): [LootMatrix]
+	CelebrationParameters(id: Int, animation: String, backgroundObject: Objects, duration: Float, subText: String, mainText: String, iconID: Icons, celeLeadIn: Float, celeLeadOut: Float, cameraPathLOT: Objects, pathNodeName: String, ambientR: Float, ambientG: Float, ambientB: Float, directionalR: Float, directionalG: Float, directionalB: Float, specularR: Float, specularG: Float, specularB: Float, lightPositionX: Float, lightPositionY: Float, lightPositionZ: Float, blendTime: Float, fogColorR: Float, fogColorG: Float, fogColorB: Float, musicCue: String, soundGUID: String, mixerProgram: String): [CelebrationParameters]
+	RarityTableIndex(RarityTable: [RarityTable!], RarityTable_RarityTableIndex: [RarityTable!], RarityTableIndex: Int): [RarityTableIndex]
+	ChoiceBuildComponent(id: Int, selections: String, imaginationOverride: Int): [ChoiceBuildComponent]
+	ZoneLoadingTips(id: Int, zoneid: ZoneTable, imagelocation: String, localize: Int, gate_version: FeatureGating, locStatus: Int, weight: Int, targetVersion: FeatureGating, tip1_loc: String, tip1_en_US: String, tip1_de_DE: String, tip1_en_GB: String, tip2_loc: String, tip2_en_US: String, tip2_de_DE: String, tip2_en_GB: String, title_loc: String, title_en_US: String, title_de_DE: String, title_en_GB: String): [ZoneLoadingTips]
+	FeatureGating(featureName: String, major: Int, current: Int, minor: Int, description: String, Activities: [Activities!], Activities_gate_version: [Activities!], ActivityText: [ActivityText!], ActivityText_gate_version: [ActivityText!], DeletionRestrictions: [DeletionRestrictions!], DeletionRestrictions_gate_version: [DeletionRestrictions!], Emotes: [Emotes!], Emotes_gate_version: [Emotes!], LootMatrix: [LootMatrix!], LootMatrix_gate_version: [LootMatrix!], MissionEmail: [MissionEmail!], MissionEmail_gate_version: [MissionEmail!], MissionNPCComponent: [MissionNPCComponent!], MissionNPCComponent_gate_version: [MissionNPCComponent!], Missions: [Missions!], Missions_gate_version: [Missions!], MissionTasks: [MissionTasks!], MissionTasks_gate_version: [MissionTasks!], MissionText: [MissionText!], MissionText_gate_version: [MissionText!], Objects: [Objects!], Objects_gate_version: [Objects!], PlayerStatistics: [PlayerStatistics!], PlayerStatistics_gate_version: [PlayerStatistics!], PropertyTemplate: [PropertyTemplate!], PropertyTemplate_gate_version: [PropertyTemplate!], RewardCodes: [RewardCodes!], RewardCodes_gate_version: [RewardCodes!], Preconditions: [Preconditions!], Preconditions_gate_version: [Preconditions!], SkillBehavior: [SkillBehavior!], SkillBehavior_gate_version: [SkillBehavior!], SpeedchatMenu: [SpeedchatMenu!], SpeedchatMenu_gate_version: [SpeedchatMenu!], UGBehaviorSounds: [UGBehaviorSounds!], UGBehaviorSounds_gate_version: [UGBehaviorSounds!], WhatsCoolItemSpotlight: [WhatsCoolItemSpotlight!], WhatsCoolItemSpotlight_gate_version: [WhatsCoolItemSpotlight!], WhatsCoolNewsAndTips: [WhatsCoolNewsAndTips!], WhatsCoolNewsAndTips_gate_version: [WhatsCoolNewsAndTips!], ZoneLoadingTips_gate_version: [ZoneLoadingTips!], ZoneLoadingTips_targetVersion: [ZoneLoadingTips!]): [FeatureGating]
+	ItemSetSkills(SkillSetID: Int, SkillID: SkillBehavior, SkillCastType: Int): [ItemSetSkills]
+	BehaviorTemplateName(templateID: Int, name: String, BehaviorTemplate: [BehaviorTemplate!], BehaviorTemplate_templateID: [BehaviorTemplate!]): [BehaviorTemplateName]
+	PackageComponent(id: Int, LootMatrixIndex: LootMatrix, packageType: Int): [PackageComponent]
+	ProximityTypes(id: Int, Name: String, Radius: Int, CollisionGroup: Int, PassiveChecks: Int, IconID: Icons, LoadOnClient: Int, LoadOnServer: Int): [ProximityTypes]
+	CurrencyDenominations(value: Int, objectid: Objects): [CurrencyDenominations]
+	Missions(MissionPrereqs_mission: [MissionPrereqs!], MissionPrereqs_prereqMission: [MissionPrereqs!], MissionTaskMissions: [MissionTaskMissions!], MissionTaskMissions_mission: [MissionTaskMissions!], CollectibleComponent: [CollectibleComponent!], CollectibleComponent_requirement_mission: [CollectibleComponent!], MissionEmail: [MissionEmail!], MissionEmail_missionID: [MissionEmail!], MissionNPCComponent: [MissionNPCComponent!], MissionNPCComponent_missionID: [MissionNPCComponent!], id: Int, defined_type: String, defined_subtype: String, UISortOrder: Int, offer_objectID: Objects, target_objectID: Objects, reward_currency: Int, LegoScore: Int, reward_reputation: Int, isChoiceReward: Int, reward_item1: Objects, reward_item1_count: Int, reward_item2: Objects, reward_item2_count: Int, reward_item3: Objects, reward_item3_count: Int, reward_item4: Objects, reward_item4_count: Int, reward_emote: Emotes, reward_emote2: Emotes, reward_emote3: Emotes, reward_emote4: Emotes, reward_maximagination: Int, reward_maxhealth: Int, reward_maxinventory: Int, reward_maxmodel: Int, reward_maxwidget: Int, reward_maxwallet: Int, repeatable: Int, reward_currency_repeatable: Int, reward_item1_repeatable: Objects, reward_item1_repeat_count: Int, reward_item2_repeatable: Objects, reward_item2_repeat_count: Int, reward_item3_repeatable: Objects, reward_item3_repeat_count: Int, reward_item4_repeatable: Objects, reward_item4_repeat_count: Int, time_limit: Int, isMission: Int, missionIconID: Icons, prereqMissionID: String, localize: Int, inMOTD: Int, cooldownTime: Int, isRandom: Int, randomPool: String, UIPrereqID: Int, gate_version: FeatureGating, HUDStates: String, locStatus: Int, reward_bankinventory: Int, name_loc: String, name_en_US: String, name_de_DE: String, name_en_GB: String, MissionTasks: [MissionTasks!], MissionTasks_id: [MissionTasks!], MissionText: [MissionText!], MissionText_id: [MissionText!]): [Missions]
+	ZoneTable(Activities: [Activities!], Activities_instanceMapID: [Activities!], LUPZoneIDs: [LUPZoneIDs!], LUPZoneIDs_zoneID: [LUPZoneIDs!], PropertyEntranceComponent: [PropertyEntranceComponent!], PropertyEntranceComponent_mapID: [PropertyEntranceComponent!], PropertyTemplate_mapID: [PropertyTemplate!], PropertyTemplate_vendorMapID: [PropertyTemplate!], RocketLaunchpadControlComponent_targetZone: [RocketLaunchpadControlComponent!], RocketLaunchpadControlComponent_defaultZoneID: [RocketLaunchpadControlComponent!], ZoneLoadingTips: [ZoneLoadingTips!], ZoneLoadingTips_zoneid: [ZoneLoadingTips!], ZoneSummary: [ZoneSummary!], ZoneSummary_zoneID: [ZoneSummary!], zoneID: Int, locStatus: Int, zoneName: String, scriptID: Int, ghostdistance_min: Float, ghostdistance: Float, population_soft_cap: Int, population_hard_cap: Int, DisplayDescription: String, mapFolder: String, smashableMinDistance: Float, smashableMaxDistance: Float, mixerProgram: String, clientPhysicsFramerate: String, serverPhysicsFramerate: String, zoneControlTemplate: Int, widthInChunks: Int, heightInChunks: Int, petsAllowed: Int, localize: Int, fZoneWeight: Float, thumbnail: String, PlayerLoseCoinsOnDeath: Int, disableSaveLoc: Int, teamRadius: Float, gate_version: FeatureGating, mountsAllowed: Int, DisplayDescription_loc: String, DisplayDescription_en_US: String, DisplayDescription_de_DE: String, DisplayDescription_en_GB: String, summary_loc: String, summary_en_US: String, summary_de_DE: String, summary_en_GB: String): [ZoneTable]
+	DeletionRestrictions(id: Int, restricted: Int, ids: String, checkType: Int, localize: Int, locStatus: Int, gate_version: FeatureGating, failureReason_loc: String, failureReason_en_US: String, failureReason_de_DE: String, failureReason_en_GB: String): [DeletionRestrictions]
+	InventoryComponent(id: Int, itemid: Objects, count: Int, equip: Int): [InventoryComponent]
+	ExhibitComponent(id: Int, length: Float, width: Float, height: Float, offsetX: Float, offsetY: Float, offsetZ: Float, fReputationSizeMultiplier: Float, fImaginationCost: Float): [ExhibitComponent]
+	ZoneSummary(zoneID: ZoneTable, type: Int, value: Int, _uniqueID: Int): [ZoneSummary]
+	ItemEggData(id: Int, chassie_type_id: Int): [ItemEggData]
+	mapAssetType(id: Int, label: String, pathdir: String, typelabel: String): [mapAssetType]
+	MinifigComponent(id: Int, head: Int, chest: Int, legs: Int, hairstyle: Int, haircolor: Int, chestdecal: Int, headcolor: Int, lefthand: Int, righthand: Int, eyebrowstyle: MinifigDecals_Eyebrows, eyesstyle: MinifigDecals_Eyes, mouthstyle: MinifigDecals_Mouths): [MinifigComponent]
+	LUPZoneIDs(zoneID: ZoneTable): [LUPZoneIDs]
+	ItemComponent(id: Int, equipLocation: String, baseValue: Int, isKitPiece: Int, rarity: Int, itemType: mapItemTypes, itemInfo: Int, inLootTable: Int, inVendor: Int, isUnique: Int, isBOP: Int, isBOE: Int, reqFlagID: Int, reqSpecialtyID: Int, reqSpecRank: Int, reqAchievementID: Int, stackSize: Int, color1: Int, decal: Int, offsetGroupID: Int, buildTypes: Int, reqPrecondition: String, animationFlag: Int, equipEffects: Int, readyForQA: Int, itemRating: Int, isTwoHanded: Int, minNumRequired: Int, delResIndex: Int, currencyLOT: Objects, altCurrencyCost: Int, subItems: String, audioEventUse: String, noEquipAnimation: Int, commendationLOT: Objects, commendationCost: Int, audioEquipMetaEventSet: String, currencyCosts: String, ingredientInfo: String, locStatus: Int, forgeType: Int, SellMultiplier: Float, ingredientInfo_loc: String, ingredientInfo_en_US: String, ingredientInfo_de_DE: String, ingredientInfo_en_GB: String, Objects: [Objects!], Objects_itemComponent: [Objects!]): [ItemComponent]
+	MovementAIComponent(id: Int, MovementType: String, WanderChance: Float, WanderDelayMin: Float, WanderDelayMax: Float, WanderSpeed: Float, WanderRadius: Float, attachedPath: String): [MovementAIComponent]
+	mapRenderEffects(id: Int, gameID: Int, description: String): [mapRenderEffects]
+	RebuildSections(id: Int, rebuildID: Int, objectID: Objects, offset_x: Float, offset_y: Float, offset_z: Float, fall_angle_x: Float, fall_angle_y: Float, fall_angle_z: Float, fall_height: Float, requires_list: String, size: Int, bPlaced: Int): [RebuildSections]
+	PlayerStatistics(statID: Int, sortOrder: Int, locStatus: Int, gate_version: FeatureGating, statStr_loc: String, statStr_en_US: String, statStr_de_DE: String, statStr_en_GB: String): [PlayerStatistics]
+}

--- a/src/app/util/services/graphql.ts
+++ b/src/app/util/services/graphql.ts
@@ -1,0 +1,49 @@
+import { Injectable } from "@angular/core";
+import { LuCoreDataService } from "app/services";
+import { Observable } from "rxjs";
+
+class GQL {
+  template: TemplateStringsArray;
+  args: GQL[];
+
+  constructor(template: TemplateStringsArray, args: GQL[]) {
+    this.template = template;
+    this.args = args;
+  }
+
+  render(): string {
+    return this.template.join("") + this.args.map(x => x.template).join("");
+  }
+}
+
+export function gql(template: TemplateStringsArray, ...args: GQL[]): GQL {
+  return new GQL(template, args);
+}
+
+export class Query<Output, Input> {
+  apollo: Apollo;
+  document: GQL;
+
+  constructor(apollo: Apollo) {
+    this.apollo = apollo;
+  }
+
+  watch(variables: Input): { valueChanges: Observable<Output> } {
+    let doc = this.document.render();
+    for (const key in variables) {
+      doc = doc.replace(new RegExp(": \\$"+key, "g"), ": "+variables[key]);
+    }
+    return { valueChanges: this.apollo.luCoreData.queryGraphQl<Output>(doc) };
+  }
+};
+
+@Injectable({
+  providedIn: "root"
+})
+export class Apollo {
+  luCoreData: LuCoreDataService;
+
+  constructor(luCoreData: LuCoreDataService) {
+    this.luCoreData = luCoreData;
+  }
+}

--- a/src/app/util/services/lu-core-data.service.ts
+++ b/src/app/util/services/lu-core-data.service.ts
@@ -99,6 +99,10 @@ export class LuCoreDataService {
     return this.cache.get(url);
   }
 
+  queryGraphQl<T>(query: string): Observable<T> {
+    return this.get("v0/graphql/"+encodeURIComponent(query));
+  }
+
   querySql(query: string): Observable<any[]> {
     return this.get("v0/query/"+encodeURIComponent(query), "text", map(this.parseCsv));
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
       "node_modules/@types"
     ],
     "lib": [
-      "es2017",
+      "es2018",
       "dom",
       "esnext.bigint"
     ],


### PR DESCRIPTION
Adds an API for GraphQL requests, and a build script to autogenerate TS types from a GraphQL schema + GraphQL queries.

The most commonly used GraphQL client seems to be Apollo, but I'm not convinced it's not overkill for this usecase. In order to keep the dependencies lightweight but also keep our options open in the future, I've instead written a simple shim compatible with the codegen intended for Apollo but not actually using Apollo as a dependency.

Since the GraphQL API doesn't get called yet, this PR is fully backwards compatible.